### PR TITLE
Added  RADIUS and TACACS limitation

### DIFF
--- a/content/cumulus-linux/System-Configuration/Authentication,-Authorization-and-Accounting/RADIUS-AAA.md
+++ b/content/cumulus-linux/System-Configuration/Authentication,-Authorization-and-Accounting/RADIUS-AAA.md
@@ -310,16 +310,16 @@ file, use that account name instead of *radius\_user*.
 
 ## Limitations
 
-If two or more RADIUS users are logged in simultaneously, a UID lookup
+- If two or more RADIUS users are logged in simultaneously, a UID lookup
 only returns the user that logged in first. Any processes run by either
 user get attributed to both, and all files created by either user get
 attributed to the first name matched. This is similar to adding two
 local users to the password file with the same UID and GID, and is an
 inherent limitation of using the UID for the fixed user from the
-password file.
-
-The current algorithm returns the first name matching the UID from the
+password file. The current algorithm returns the first name matching the UID from the
 mapping file; this might be the first or second user that logged in.
+
+- When you have both the TACACS+ and the RADIUS AAA client installed, RADIUS login is not attempted. As a workaround, do not install both the TACACS+ and the RADIUS AAA client on the same switch.
 
 ## Related Information
 

--- a/content/cumulus-linux/System-Configuration/Authentication,-Authorization-and-Accounting/TACACS-Plus.md
+++ b/content/cumulus-linux/System-Configuration/Authentication,-Authorization-and-Accounting/TACACS-Plus.md
@@ -693,3 +693,7 @@ users.
 
 Only use the `--remove-home` option when the `user_homedir=1`
 configuration command is in use.
+
+### When Both TACACS+ and RADIUS AAA Clients are Installed
+
+When you have both the TACACS+ and the RADIUS AAA client installed, RADIUS login is not attempted. As a workaround, do not install both the TACACS+ and the RADIUS AAA client on the same switch.


### PR DESCRIPTION
Added limitation that when  both the TACACS+ and the RADIUS AAA client installed, RADIUS login is not attempted.