### PR TITLE
Update aliases for VX, RMP and chassis

### DIFF
--- a/content/chassis/Accessing-the-Console.md
+++ b/content/chassis/Accessing-the-Console.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 11
 aliases:
  - /display/CHASSIS/Accessing-the-Console
+ - /display/CHASSIS/Accessing+the+Console
  - /pages/viewpage.action?pageId=7766291
 pageID: 7766291
 product: Cumulus Chassis

--- a/content/chassis/Chassis-Default-Configurations.md
+++ b/content/chassis/Chassis-Default-Configurations.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 15
 aliases:
  - /display/CHASSIS/Chassis-Default-Configurations
+ - /display/CHASSIS/Chassis+Default+Configurations
  - /pages/viewpage.action?pageId=7113477
 pageID: 7113477
 product: Cumulus Chassis

--- a/content/chassis/Chassis-specific-Commands.md
+++ b/content/chassis/Chassis-specific-Commands.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 19
 aliases:
  - /display/CHASSIS/Chassis-specific-Commands
+ - /display/CHASSIS/Chassis-specific+Commands
  - /pages/viewpage.action?pageId=7766308
 pageID: 7766308
 product: Cumulus Chassis

--- a/content/chassis/Fabric-Port,-Line-Card-and-Switch-Port-Interfaces.md
+++ b/content/chassis/Fabric-Port,-Line-Card-and-Switch-Port-Interfaces.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 13
 aliases:
  - '/display/CHASSIS/Fabric-Port,-Line-Card-and-Switch-Port-Interfaces'
+ - '/display/CHASSIS/Fabric+Port,+Line+Card+and+Switch+Port+Interfaces'
  - /pages/viewpage.action?pageId=7766298
 pageID: 7766298
 product: Cumulus Chassis

--- a/content/chassis/Monitoring-and-Troubleshooting-a-Chassis.md
+++ b/content/chassis/Monitoring-and-Troubleshooting-a-Chassis.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 17
 aliases:
  - /display/CHASSIS/Monitoring-and-Troubleshooting-a-Chassis
+ - /display/CHASSIS/Monitoring+and+Troubleshooting+a+Chassis
  - /pages/viewpage.action?pageId=7113871
 pageID: 7113871
 product: Cumulus Chassis

--- a/content/chassis/_index.md
+++ b/content/chassis/_index.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 1
 aliases:
  - /display/CHASSIS/Chassis-User-Guide
+ - /display/CHASSIS/Chassis+User+Guide
  - /pages/viewpage.action?pageId=6488345
 pageID: 6488345
 product: Cumulus Chassis

--- a/content/cumulus-rmp/Quick-Start-Guide.md
+++ b/content/cumulus-rmp/Quick-Start-Guide.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 11
 aliases:
  - /display/RMP/Quick-Start-Guide
+ - /display/RMP/Quick+Start+Guide
  - /pages/viewpage.action?pageId=5122816
 pageID: 5122816
 product: Cumulus RMP

--- a/content/cumulus-rmp/_index.md
+++ b/content/cumulus-rmp/_index.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: -37
 aliases:
  - /display/RMP/Cumulus-RMP
+ - /display/RMP/Cumulus+RMP
  - /pages/viewpage.action?pageId=5122807
 pageID: 5122807
 product: Cumulus RMP

--- a/content/cumulus-vx/Comparing-Cumulus-VX-to-other-Cumulus-Networks-Products.md
+++ b/content/cumulus-vx/Comparing-Cumulus-VX-to-other-Cumulus-Networks-Products.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 13
 aliases:
  - /display/VX/Comparing-Cumulus-VX-to-other-Cumulus-Networks-Products
+ - /display/VX/Comparing+Cumulus+VX+to+other+Cumulus+Networks+Products
  - /pages/viewpage.action?pageId=5126709
 pageID: 5126709
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Create-a-Two-Leaf,-Two-Spine-Topology.md
+++ b/content/cumulus-vx/Create-a-Two-Leaf,-Two-Spine-Topology.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 21
 aliases:
  - '/display/VX/Create-a-Two-Leaf,-Two-Spine-Topology'
+ - '/display/VX/Create+a+Two+Leaf,+Two+Spine+Topology'
  - /pages/viewpage.action?pageId=5126706
 pageID: 5126706
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Cumulus-VX-Support-Policy.md
+++ b/content/cumulus-vx/Cumulus-VX-Support-Policy.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 15
 aliases:
  - /display/VX/Cumulus-VX-Support-Policy
+ - /display/VX/Cumulus+VX+Support+Policy
  - /pages/viewpage.action?pageId=5126708
 pageID: 5126708
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Development-Environments/GNS3-and-QEMU-KVM.md
+++ b/content/cumulus-vx/Development-Environments/GNS3-and-QEMU-KVM.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 65
 aliases:
  - /display/VX/GNS3-and-QEMU-KVM
+ - /display/VX/GNS3+and+QEMU+KVM
  - /pages/viewpage.action?pageId=5126717
 pageID: 5126717
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Development-Environments/GNS3-and-VirtualBox.md
+++ b/content/cumulus-vx/Development-Environments/GNS3-and-VirtualBox.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 63
 aliases:
  - /display/VX/GNS3-and-VirtualBox
+  - /display/VX/GNS3+and+VirtualBox
  - /pages/viewpage.action?pageId=5126714
 pageID: 5126714
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Development-Environments/Vagrant-and-Libvirt-with-KVM-or-QEMU.md
+++ b/content/cumulus-vx/Development-Environments/Vagrant-and-Libvirt-with-KVM-or-QEMU.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 61
 aliases:
  - /display/VX/Vagrant-and-Libvirt-with-KVM-or-QEMU
+ - /display/VX/Vagrant+and+Libvirt+with+KVM+or+QEMU
  - /pages/viewpage.action?pageId=5126718
 pageID: 5126718
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Development-Environments/Vagrant-and-VirtualBox.md
+++ b/content/cumulus-vx/Development-Environments/Vagrant-and-VirtualBox.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 59
 aliases:
  - /display/VX/Vagrant-and-VirtualBox
+ - /display/VX/Vagrant+and+VirtualBox
  - /pages/viewpage.action?pageId=5126719
 pageID: 5126719
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Development-Environments/_index.md
+++ b/content/cumulus-vx/Development-Environments/_index.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 19
 aliases:
  - /display/VX/Development-Environments
+ - /display/VX/Development+Environments
  - /pages/viewpage.action?pageId=5126712
 pageID: 5126712
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Getting-Started/Libvirt-and-KVM-QEMU.md
+++ b/content/cumulus-vx/Getting-Started/Libvirt-and-KVM-QEMU.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 45
 aliases:
  - /display/VX/Libvirt-and-KVM-QEMU
+ - /display/VX/Libvirt+and+KVM+QEMU
  - /pages/viewpage.action?pageId=5126704
 pageID: 5126704
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Getting-Started/ONIE-Virtual-Machine.md
+++ b/content/cumulus-vx/Getting-Started/ONIE-Virtual-Machine.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 47
 aliases:
  - /display/VX/ONIE-Virtual-Machine
+ - /display/VX/ONIE+Virtual+Machine
  - /pages/viewpage.action?pageId=5126699
 pageID: 5126699
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Getting-Started/VMware-Fusion.md
+++ b/content/cumulus-vx/Getting-Started/VMware-Fusion.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 39
 aliases:
  - /display/VX/VMware-Fusion
+ - /display/VX/VMware+Fusion
  - /pages/viewpage.action?pageId=5126696
 pageID: 5126696
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Getting-Started/VMware-Workstation.md
+++ b/content/cumulus-vx/Getting-Started/VMware-Workstation.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 41
 aliases:
  - /display/VX/VMware-Workstation
+ - /display/VX/VMware+Workstation
  - /pages/viewpage.action?pageId=5126698
 pageID: 5126698
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Getting-Started/VMware-vSphere-ESXi-5.5.md
+++ b/content/cumulus-vx/Getting-Started/VMware-vSphere-ESXi-5.5.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 37
 aliases:
  - /display/VX/VMware-vSphere-ESXi-5.5
+ - /display/VX/VMware+vSphere+ESXi+5.5
  - /pages/viewpage.action?pageId=5126689
 pageID: 5126689
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Getting-Started/VirtualBox.md
+++ b/content/cumulus-vx/Getting-Started/VirtualBox.md
@@ -7,7 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5126701
 pageID: 5126701
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Getting-Started/_index.md
+++ b/content/cumulus-vx/Getting-Started/_index.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 17
 aliases:
  - /display/VX/Getting-Started
+ - /display/VX/Getting+Started
  - /pages/viewpage.action?pageId=5126687
 pageID: 5126687
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/Next-Steps.md
+++ b/content/cumulus-vx/Next-Steps.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 23
 aliases:
  - /display/VX/Next-Steps
+ - /display/VX/Next+Steps
  - /pages/viewpage.action?pageId=5126707
 pageID: 5126707
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/What's-New-in-Cumulus-VX.md
+++ b/content/cumulus-vx/What's-New-in-Cumulus-VX.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: 11
 aliases:
  - /display/VX/What's-New-in-Cumulus-VX
+ - /display/VX/What's+New+in+Cumulus+VX
  - /pages/viewpage.action?pageId=5126710
 pageID: 5126710
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 ---

--- a/content/cumulus-vx/_index.md
+++ b/content/cumulus-vx/_index.md
@@ -4,10 +4,11 @@ author: Cumulus Networks
 weight: -34
 aliases:
  - /display/VX/Cumulus-VX-Documentation
+ - /display/VX/
  - /pages/viewpage.action?pageId=5126686
 pageID: 5126686
 product: Cumulus VX
-version: '3.4'
+version: '3.7'
 imgData: cumulus-vx
 siteSlug: cumulus-vx
 subsection: true


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

For some reason, the aliases to the Cumulus RMP, VX and Chassis guides
were using dashes instead of plus signs.