### PR TITLE
Remove apostrophe from some links

### DIFF
--- a/content/cumulus-vx/What's-New-in-Cumulus-VX.md
+++ b/content/cumulus-vx/What's-New-in-Cumulus-VX.md
@@ -5,6 +5,8 @@ weight: 11
 aliases:
  - /display/VX/What's-New-in-Cumulus-VX
  - /display/VX/What's+New+in+Cumulus+VX
+ - /display/VX/Whats-New-in-Cumulus-VX
+ - /display/VX/Whats+New+in+Cumulus+VX
  - /pages/viewpage.action?pageId=5126710
 pageID: 5126710
 product: Cumulus VX

--- a/content/cumulus-vx/_index.md
+++ b/content/cumulus-vx/_index.md
@@ -55,7 +55,7 @@ In addition, you can use Cumulus VX with the following development environments:
 
 ## Documentation
 
-- [What's New in Cumulus VX](/cumulus-vx/What's-New-in-Cumulus-VX)
+- [What's New in Cumulus VX](/cumulus-vx/Whats-New-in-Cumulus-VX/)
 - [Cumulus VX Support Policy](/cumulus-vx/Cumulus-VX-Support-Policy)
 - [Comparing Cumulus VX to other Cumulus Networks Products](/cumulus-vx/Comparing-Cumulus-VX-to-other-Cumulus-Networks-Products)
 - [Getting Started](/cumulus-vx/Getting-Started/)

--- a/content/version/cumulus-linux-30/What's-New-in-Cumulus-Linux-3.0.1.md
+++ b/content/version/cumulus-linux-30/What's-New-in-Cumulus-Linux-3.0.1.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 11
 aliases:
  - /display/CL30/What's+New+in+Cumulus+Linux+3.0.1
+ - /display/CL30/Whats+New+in+Cumulus+Linux+3.0.1
  - /pages/viewpage.action?pageId=5118422
 pageID: 5118422
 product: Cumulus Linux

--- a/content/version/cumulus-linux-30/_index.md
+++ b/content/version/cumulus-linux-30/_index.md
@@ -40,7 +40,7 @@ documentation.
     Linux 3.0.1](https://support.cumulusnetworks.com/hc/en-us/articles/222822047)
 
   - [What's New in Cumulus Linux
-    3.0.1](/version/cumulus-linux-30/What's-New-in-Cumulus-Linux-3.0.1)
+    3.0.1](/version/cumulus-linux-30/Whats-New-in-Cumulus-Linux-3.0.1)
 
   - [Quick Start Guide](/version/cumulus-linux-30/Quick-Start-Guide)
 

--- a/content/version/cumulus-linux-31/What's-New-in-Cumulus-Linux-3.1.md
+++ b/content/version/cumulus-linux-31/What's-New-in-Cumulus-Linux-3.1.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 11
 aliases:
  - /display/CL31/What's+New+in+Cumulus+Linux+3.1
+ - /display/CL31/Whats+New+in+Cumulus+Linux+3.1
  - /pages/viewpage.action?pageId=5122208
 pageID: 5122208
 product: Cumulus Linux

--- a/content/version/cumulus-rmp-30/What's-New-in-Cumulus-RMP-3.0.0.md
+++ b/content/version/cumulus-rmp-30/What's-New-in-Cumulus-RMP-3.0.0.md
@@ -4,6 +4,7 @@ author: Cumulus Networks
 weight: 11
 aliases:
  - /display/RMP30/What's+New+in+Cumulus+RMP+3.0.0
+ - /display/RMP30/Whats+New+in+Cumulus+RMP+3.0.0
  - /pages/viewpage.action?pageId=5118741
 pageID: 5118741
 product: Cumulus RMP


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Some Confluence page titles had apostrophes in them
(all What's New pages), but the Hugo links from the import did not.
This fixes that, removing the apostrophe from the links.