### PR TITLE
Fix bridge-access definition

### DIFF
--- a/content/cumulus-linux/Layer-2/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode.md
+++ b/content/cumulus-linux/Layer-2/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode.md
@@ -97,7 +97,8 @@ The following attributes are useful for configuring VLAN-aware bridges:
 
   - `bridge-access`: Declares the physical switch port as an *access
     port*. Access ports ignore all tagged packets; put all untagged
-    packets into the `bridge-pvid`.
+    packets into the VLAN specified for this attribute. See the example
+    [below](#untagged-access-ports).
 
   - `bridge-allow-untagged`: When set to *no*, it drops any untagged
     frames for a given switch port.

--- a/content/version/cumulus-linux-35/Layer-1-and-2/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode-for-Large-scale-Layer-2-Environments.md
+++ b/content/version/cumulus-linux-35/Layer-1-and-2/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode-for-Large-scale-Layer-2-Environments.md
@@ -95,7 +95,8 @@ The following attributes are useful for configuring VLAN-aware bridges:
 
   - `bridge-access`: Declares the physical switch port as an *access
     port*. Access ports ignore all tagged packets; put all untagged
-    packets into the `bridge-pvid`.
+    packets into the VLAN specified for this attribute. See the example
+    [below](#untagged-access-ports).
 
   - `bridge-allow-untagged`: When set to *no*, it drops any untagged
     frames for a given switch port.

--- a/content/version/cumulus-linux-36/Layer-2/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode.md
+++ b/content/version/cumulus-linux-36/Layer-2/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode.md
@@ -85,7 +85,8 @@ The following attributes are useful for configuring VLAN-aware bridges:
     VLANs associated with this bridge.
   - `bridge-access`: Declares the physical switch port as an *access
     port*. Access ports ignore all tagged packets; put all untagged
-    packets into the `bridge-pvid`.
+    packets into the VLAN specified for this attribute. See the example
+    [below](#untagged-access-ports).
   - `bridge-allow-untagged`: When set to *no*, it drops any untagged
     frames for a given switch port.
 


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Anton Slacked me about the definition here being incorrect.
This fixes the error (bridge-access specifies a VLAN for all
untagged frames; they don't go to the PVID necessarily.