### PR TITLE
Update VXLAN scale note, add aliases to DHCP relays

### DIFF
--- a/content/cumulus-linux/Layer-1-and-Switch-Ports/DHCP-Relays.md
+++ b/content/cumulus-linux/Layer-1-and-Switch-Ports/DHCP-Relays.md
@@ -4,6 +4,12 @@ author: Cumulus Networks
 weight: 95
 aliases:
  - /display/DOCS/DHCP+Relays
+ - /display/CL31/Configuring+DHCP+Relays+and+Servers
+ - /display/CL36/DHCP+Relays
+ - /display/CL35/Configuring+DHCP+Relays
+ - /display/CL34/Configuring+DHCP+Relays
+ - /display/CL33/Configuring+DHCP+Relays
+ - /display/CL321/Configuring+DHCP+Relays
  - /pages/viewpage.action?pageId=8363036
 pageID: 8363036
 product: Cumulus Linux

--- a/content/cumulus-linux/Network-Virtualization/VXLAN-Scale.md
+++ b/content/cumulus-linux/Network-Virtualization/VXLAN-Scale.md
@@ -19,7 +19,7 @@ design.
 
 {{%notice note%}}
 
-While this limitation does apply to Trident II+, Trident3, or Maverick
+While this limitation does not apply to Trident II+, Trident3, or Maverick
 ASICs, Cumulus Linux supports the same number of VXLANs on these ASICs
 as it does for Trident II or Tomahawk ASICs.
 

--- a/content/version/cumulus-linux-36/Network-Virtualization/VXLAN-Scale.md
+++ b/content/version/cumulus-linux-36/Network-Virtualization/VXLAN-Scale.md
@@ -19,7 +19,7 @@ design.
 
 {{%notice note%}}
 
-While this limitation does apply to Trident II+ or Maverick ASICs,
+While this limitation does not apply to Trident II+ or Maverick ASICs,
 Cumulus Linux supports the same number of VXLANs on these ASICs as it
 does for Trident II or Tomahawk ASICs.
 


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Added a missing "not" to the a note in the VXLAN scale chapter;
the rewrite part of UD-1544 will hold off for the time being.
Added some aliases for the two older names of the DHCP relay chapter.