### PR TITLE
ECMP hashing update UD-1656

### DIFF
--- a/content/cumulus-linux/Layer-3/Equal-Cost-Multipath-Load-Sharing-Hardware-ECMP.md
+++ b/content/cumulus-linux/Layer-3/Equal-Cost-Multipath-Load-Sharing-Hardware-ECMP.md
@@ -35,7 +35,6 @@ For routes to be considered equal they must:
   - Originate from the same routing protocol. Routes from different
     sources are not considered equal. For example, a static route and an
     OSPF route are not considered for ECMP load sharing.
-
   - Have equal cost. If two routes from the same protocol are unequal,
     only the best route is installed in the routing table.
 
@@ -57,17 +56,12 @@ Cumulus Linux hashes on the following
 fields:
 
   - IP protocol
-
-  - Ingress interface
-
   - Source IPv4 or IPv6 address
-
   - Destination IPv4 or IPv6 address
 
 For TCP/UDP frames, Cumulus Linux also hashes on:
 
   - Source port
-
   - Destination port
 
 {{% imgOld 0 %}}

--- a/content/version/cumulus-linux-36/Layer-3/Equal-Cost-Multipath-Load-Sharing-Hardware-ECMP.md
+++ b/content/version/cumulus-linux-36/Layer-3/Equal-Cost-Multipath-Load-Sharing-Hardware-ECMP.md
@@ -56,7 +56,6 @@ to determine which path a packet follows.
 Cumulus Linux hashes on the following fields:
 
   - IP protocol
-  - Ingress interface
   - Source IPv4 or IPv6 address
   - Destination IPv4 or IPv6 address
 


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Ingress interface no longer part of the hash.