### PR TITLE
Add forum widget to landing page

### DIFF
--- a/themes/netDocs/layouts/home.html
+++ b/themes/netDocs/layouts/home.html
@@ -362,6 +362,10 @@
     };
    </script>
 
+  <script>
+    (function(w,d,s){var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src='//embeddable-widgets-usw2.insided.com/cumulusnetworks-en.insided-conversational.js';f.parentNode.insertBefore(j,f);})(window,document,'script');
+  </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

baseof.html only covers article pages; home page needed the JS
separately.