### PR TITLE
Remove Trident3 from evpn caveat verbiage

### DIFF
--- a/content/cumulus-linux/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN.md
+++ b/content/cumulus-linux/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN.md
@@ -2218,7 +2218,7 @@ The following caveats apply to EVPN in this version of Cumulus Linux:
 - You must configure the overlay (tenants) in a specific VRF(s) and
     separate from the underlay, which resides in the default VRF. A
     layer 3 VNI mapping for the default VRF is not supported.
-- On the Broadcom Trident II+, Trident 3, and Maverick-based switch,
+- On the Broadcom Trident II+ and Maverick-based switch,
   when a lookup is done after VXLAN decapsulation on the
   external-facing switch (exit/border leaf), the switch does not
   rewrite the MAC addresses or TTL; for through traffic, packets are


### PR DESCRIPTION
Remove Trident3 from caveat verbiage, as Trident3 was fixed from this issue in version 3.7.7