### PR TITLE
Fix 2.5 ESR version number

### DIFF
--- a/content/version/cumulus-linux-25esr/Configuring-and-Managing-Network-Interfaces/Buffer-and-Queue-Management.md
+++ b/content/version/cumulus-linux-25esr/Configuring-and-Managing-Network-Interfaces/Buffer-and-Queue-Management.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116100
 pageID: 5116100
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Configuring-and-Managing-Network-Interfaces/Layer-1-and-Switch-Port-Attributes.md
+++ b/content/version/cumulus-linux-25esr/Configuring-and-Managing-Network-Interfaces/Layer-1-and-Switch-Port-Attributes.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116098
 pageID: 5116098
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Configuring-and-Managing-Network-Interfaces/_index.md
+++ b/content/version/cumulus-linux-25esr/Configuring-and-Managing-Network-Interfaces/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116095
 pageID: 5116095
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Adding-and-Updating-Packages.md
+++ b/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Adding-and-Updating-Packages.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115986
 pageID: 5115986
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Managing-Cumulus-Linux-Disk-Images/Installing-a-New-Cumulus-Linux-Image.md
+++ b/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Managing-Cumulus-Linux-Disk-Images/Installing-a-New-Cumulus-Linux-Image.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115997
 pageID: 5115997
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Managing-Cumulus-Linux-Disk-Images/Upgrading-Cumulus-Linux.md
+++ b/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Managing-Cumulus-Linux-Disk-Images/Upgrading-Cumulus-Linux.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116002
 pageID: 5116002
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Managing-Cumulus-Linux-Disk-Images/_index.md
+++ b/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Managing-Cumulus-Linux-Disk-Images/_index.md
@@ -6,6 +6,7 @@ aliases:
  - /display/CL25ESR/Managing+Cumulus+Linux+Disk+Images
  - /pages/viewpage.action?pageId=5115988
 pageID: 5115988
+version: 2.5 ESR
 product: Cumulus Linux
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr

--- a/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Zero-Touch-Provisioning-ZTP.md
+++ b/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/Zero-Touch-Provisioning-ZTP.md
@@ -4,9 +4,12 @@ author: Cumulus Networks
 weight: 43
 aliases:
  - /display/CL25ESR/Zero+Touch+Provisioning+++ZTP
+ - /display/CL25ESR/Zero+Touch+Provisioning+-+ZTP
+ - /display/CL25ESR/Zero+Touch+Provisioning+ZTP
  - /pages/viewpage.action?pageId=5115987
 pageID: 5115987
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/_index.md
+++ b/content/version/cumulus-linux-25esr/Installation,-Upgrading-and-Package-Management/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115985
 pageID: 5115985
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Bonding-Link-Aggregation.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Bonding-Link-Aggregation.md
@@ -9,6 +9,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116007
 pageID: 5116007
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Ethernet-Bridging-VLANs/VLAN-Tagging.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Ethernet-Bridging-VLANs/VLAN-Tagging.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116023
 pageID: 5116023
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode-for-Large-scale-Layer-2-Environments.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode-for-Large-scale-Layer-2-Environments.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116019
 pageID: 5116019
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Ethernet-Bridging-VLANs/_index.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Ethernet-Bridging-VLANs/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116009
 pageID: 5116009
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/IGMP-and-MLD-Snooping.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/IGMP-and-MLD-Snooping.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116087
 pageID: 5116087
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/LACP-Bypass.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/LACP-Bypass.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116086
 pageID: 5116086
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Link-Layer-Discovery-Protocol.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Link-Layer-Discovery-Protocol.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116004
 pageID: 5116004
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Multi-Chassis-Link-Aggregation-MLAG.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Multi-Chassis-Link-Aggregation-MLAG.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116071
 pageID: 5116071
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Integrating-Hardware-VTEPs-with-Midokura-MidoNet-and-OpenStack.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Integrating-Hardware-VTEPs-with-Midokura-MidoNet-and-OpenStack.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116040
 pageID: 5116040
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Integrating-with-VMware-NSX.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Integrating-with-VMware-NSX.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116025
 pageID: 5116025
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Lightweight-Network-Virtualization-LNV/LNV-Full-Example.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Lightweight-Network-Virtualization-LNV/LNV-Full-Example.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116058
 pageID: 5116058
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Lightweight-Network-Virtualization-LNV/LNV-VXLAN-Active-Active-Mode.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Lightweight-Network-Virtualization-LNV/LNV-VXLAN-Active-Active-Mode.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116066
 pageID: 5116066
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Lightweight-Network-Virtualization-LNV/_index.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Lightweight-Network-Virtualization-LNV/_index.md
@@ -4,9 +4,12 @@ author: Cumulus Networks
 weight: 251
 aliases:
  - /display/CL25ESR/Lightweight+Network+Virtualization+++LNV
+ - /display/CL25ESR/Lightweight+Network+Virtualization+-+LNV
+  - /display/CL25ESR/Lightweight+Network+Virtualization+LNV
  - /pages/viewpage.action?pageId=5116051
 pageID: 5116051
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Static-MAC-Bindings-with-VXLAN.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/Static-MAC-Bindings-with-VXLAN.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116068
 pageID: 5116068
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/_index.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Network-Virtualization/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116024
 pageID: 5116024
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Prescriptive-Topology-Manager-PTM.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Prescriptive-Topology-Manager-PTM.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116005
 pageID: 5116005
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Spanning-Tree-and-Rapid-Spanning-Tree.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Spanning-Tree-and-Rapid-Spanning-Tree.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116082
 pageID: 5116082
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Virtual-Router-Redundancy-VRR.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/Virtual-Router-Redundancy-VRR.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116083
 pageID: 5116083
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/_index.md
+++ b/content/version/cumulus-linux-25esr/Layer-1-and-Layer-2-Features/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116003
 pageID: 5116003
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Bidirectional-Forwarding-Detection-BFD.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Bidirectional-Forwarding-Detection-BFD.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116125
 pageID: 5116125
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Configuring-Border-Gateway-Protocol-BGP.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Configuring-Border-Gateway-Protocol-BGP.md
@@ -4,9 +4,12 @@ author: Cumulus Networks
 weight: 135
 aliases:
  - /display/CL25ESR/Configuring+Border+Gateway+Protocol+++BGP
+ - /display/CL25ESR/Configuring+Border+Gateway+Protocol+-+BGP
+ - /display/CL25ESR/Configuring+Border+Gateway+Protocol+BGP
  - /pages/viewpage.action?pageId=5116113
 pageID: 5116113
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Configuring-Quagga.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Configuring-Quagga.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116108
 pageID: 5116108
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Equal-Cost-Multipath-Load-Sharing-Hardware-ECMP.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Equal-Cost-Multipath-Load-Sharing-Hardware-ECMP.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116115
 pageID: 5116115
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Introduction-to-Routing-Protocols.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Introduction-to-Routing-Protocols.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116103
 pageID: 5116103
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Management-VRF.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Management-VRF.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116126
 pageID: 5116126
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Network-Topology.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Network-Topology.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116104
 pageID: 5116104
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Open-Shortest-Path-First-OSPF-Protocol.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Open-Shortest-Path-First-OSPF-Protocol.md
@@ -4,9 +4,12 @@ author: Cumulus Networks
 weight: 131
 aliases:
  - /display/CL25ESR/Open+Shortest+Path+First+++OSPF+++Protocol
+ - /display/CL25ESR/Open+Shortest+Path+First+-+OSPF+-+Protocol
+ - /display/CL25ESR/Open+Shortest+Path+First+OSPF+Protocol
  - /pages/viewpage.action?pageId=5116109
 pageID: 5116109
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Open-Shortest-Path-First-v3-OSPFv3-Protocol.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Open-Shortest-Path-First-v3-OSPFv3-Protocol.md
@@ -4,9 +4,12 @@ author: Cumulus Networks
 weight: 133
 aliases:
  - /display/CL25ESR/Open+Shortest+Path+First+v3+++OSPFv3+++Protocol
+ - /display/CL25ESR/Open+Shortest+Path+First+v3+-+OSPFv3+-+Protocol
+ - /display/CL25ESR/Open+Shortest+Path+First+v3+OSPFv3+Protocol
  - /pages/viewpage.action?pageId=5116112
 pageID: 5116112
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Quagga-Overview.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Quagga-Overview.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116106
 pageID: 5116106
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Routing.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Routing.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116102
 pageID: 5116102
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Layer-3-Features/_index.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116101
 pageID: 5116101
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Managing-Application-Daemons.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Managing-Application-Daemons.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115967
 pageID: 5115967
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-Interfaces-and-Transceivers-Using-ethtool.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-Interfaces-and-Transceivers-Using-ethtool.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115963
 pageID: 5115963
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-System-Hardware.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-System-Hardware.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115965
 pageID: 5115965
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115966
 pageID: 5115966
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-Virtual-Device-Counters.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Monitoring-Virtual-Device-Counters.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115974
 pageID: 5115974
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Network-Troubleshooting.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Network-Troubleshooting.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115968
 pageID: 5115968
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Resource-Diagnostics-Using-cl-resource-query.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Resource-Diagnostics-Using-cl-resource-query.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115964
 pageID: 5115964
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/SNMP-Monitoring.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/SNMP-Monitoring.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115976
 pageID: 5115976
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Single-User-Mode-Boot-Recovery.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Single-User-Mode-Boot-Recovery.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115975
 pageID: 5115975
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Troubleshooting-Network-Interfaces.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Troubleshooting-Network-Interfaces.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115973
 pageID: 5115973
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/Troubleshooting-Log-Files.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/Troubleshooting-Log-Files.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115971
 pageID: 5115971
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/Troubleshooting-the-etc-Directory.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/Troubleshooting-the-etc-Directory.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115970
 pageID: 5115970
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/Troubleshooting-the-support-Directory.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/Troubleshooting-the-support-Directory.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115972
 pageID: 5115972
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---
@@ -17,11 +18,3 @@ commands. For example:
 | File            | Equivalent Command               | Description                                                                                                                  |
 | --------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | support/ip.addr | `cumulus@switch:~$ ip addr show` | This shows you all the interfaces (including swp front panel ports), IP address information, admin state and physical state. |
-
-<article id="html-search-results" class="ht-content" style="display: none;">
-
-</article>
-
-<footer id="ht-footer">
-
-</footer>

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/_index.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Understanding-and-Decoding-the-cl-support-Output-File/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115969
 pageID: 5115969
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Using-netshow-to-Troubleshoot-Your-Network-Configuration.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/Using-netshow-to-Troubleshoot-Your-Network-Configuration.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115984
 pageID: 5115984
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/_index.md
+++ b/content/version/cumulus-linux-25esr/Monitoring-and-Troubleshooting/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115962
 pageID: 5115962
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Network-Solutions/Cumulus-Networks-Services-Demos.md
+++ b/content/version/cumulus-linux-25esr/Network-Solutions/Cumulus-Networks-Services-Demos.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116152
 pageID: 5116152
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Network-Solutions/Data-Center-Host-to-ToR-Architecture.md
+++ b/content/version/cumulus-linux-25esr/Network-Solutions/Data-Center-Host-to-ToR-Architecture.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116133
 pageID: 5116133
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/Network-Solutions/_index.md
+++ b/content/version/cumulus-linux-25esr/Network-Solutions/_index.md
@@ -7,13 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116132
 pageID: 5116132
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---
-<article id="html-search-results" class="ht-content" style="display: none;">
-
-</article>
-
-<footer id="ht-footer">
-
-</footer>

--- a/content/version/cumulus-linux-25esr/Quick-Start-Guide/_index.md
+++ b/content/version/cumulus-linux-25esr/Quick-Start-Guide/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115897
 pageID: 5115897
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/LDAP-Authentication-and-Authorization.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/LDAP-Authentication-and-Authorization.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115904
 pageID: 5115904
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/SSH-for-Remote-Access.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/SSH-for-Remote-Access.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115901
 pageID: 5115901
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/User-Accounts.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/User-Accounts.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115902
 pageID: 5115902
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/Using-sudo-to-Delegate-Privileges.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/Using-sudo-to-Delegate-Privileges.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115903
 pageID: 5115903
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/_index.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Authentication,-Authorization,-and-Accounting/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115900
 pageID: 5115900
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Configuring-a-Global-Proxy.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Configuring-a-Global-Proxy.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115910
 pageID: 5115910
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Configuring-switchd.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Configuring-switchd.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115907
 pageID: 5115907
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Netfilter-ACLs.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Netfilter-ACLs.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115908
 pageID: 5115908
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Power-over-Ethernet-PoE.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Power-over-Ethernet-PoE.md
@@ -9,6 +9,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115909
 pageID: 5115909
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/Setting-Date-and-Time.md
+++ b/content/version/cumulus-linux-25esr/System-Management/Setting-Date-and-Time.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115899
 pageID: 5115899
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/System-Management/_index.md
+++ b/content/version/cumulus-linux-25esr/System-Management/_index.md
@@ -7,6 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115898
 pageID: 5115898
 product: Cumulus Linux
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---

--- a/content/version/cumulus-linux-25esr/_index.md
+++ b/content/version/cumulus-linux-25esr/_index.md
@@ -7,8 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5115887
 pageID: 5115887
 product: Cumulus Linux
-cascade: 
-  version: 2.5 ESR
+version: 2.5 ESR
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 subsection: true


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Version number in the dropdown got hosed when I tried upgrading Hugo and
tested the cascade feature.