### PR TITLE
Update Virtual-Router-Redundancy-VRR-and-VRRP.md

### DIFF
--- a/content/cumulus-linux/Layer-2/Virtual-Router-Redundancy-VRR-and-VRRP.md
+++ b/content/cumulus-linux/Layer-2/Virtual-Router-Redundancy-VRR-and-VRRP.md
@@ -467,7 +467,7 @@ the IP addresses of the virtual router.
 - Cumulus Linux supports both VRRPv2 and VRRPv3. The default protocol version is VRRPv3.
 - 255 virtual routers are supported per switch.
 - VRRP is not supported currently in an MLAG environment or with EVPN.
-- To configure VRRP on an SVI, you need to edit the `/etc/frr/frr.conf` file; The NCLU commands are not supported for SVIs.
+- To configure VRRP on an SVI/traditional bridges, you need to edit the `etc/network/interfaces` and `/etc/frr/frr.conf` files; The NCLU commands are not supported for SVIs/Traditional bridges.
 
 {{%/notice%}}
 


### PR DESCRIPTION
We have some open issues enabling VRRP on SVIs/Traditional Bridges through NCLU. So, I've updated Traditional bridge as well here. Along with this, when we don't have to use NCLU, we will have to mention that both /etc/network/interfaces and /etc/frr/frr.conf are used to enable VRRP on these interfaces. 