### PR TITLE
L2, target=blank

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -92,7 +92,6 @@ showVisitedLinks = true
   BookDateFormat= "Jan 2, 2006"
 
 [blackfriday]
-hrefTargetBlank = true
 fractions = false
 
 [taxonomies]

--- a/content/cumulus-linux/Layer-2/_index.md
+++ b/content/cumulus-linux/Layer-2/_index.md
@@ -11,3 +11,4 @@ version: 3.7
 imgData: cumulus-linux
 siteSlug: cumulus-linux
 ---
+This section describes layer 2 configuration. Read this section to understand [bridging](Ethernet-Bridging-VLANs/), [bonding](Bonding-Link-Aggregation/), [multi-chassis link aggregation](Multi-Chassis-Link-Aggregation-MLAG/) (MLAG), [link layer discovery protocol](Link-Layer-Discovery-Protocol/) (LLDP), [LACP bypass](LACP-Bypass/), [virtual router redundancy](Virtual-Router-Redundancy-VRR-and-VRRP/) and [IGMP and MLD snooping](IGMP-and-MLD-Snooping/).


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Add description to the L2 landing page
Remove `hrefTargetBlank = true` from config.toml so
links within the docs don't open in new tab.