### PR TITLE
ESR version number doesn't appear in search

### DIFF
--- a/content/version/cumulus-linux-25esr/Layer-3-Features/Management-VRF.md
+++ b/content/version/cumulus-linux-25esr/Layer-3-Features/Management-VRF.md
@@ -7,7 +7,7 @@ aliases:
  - /pages/viewpage.action?pageId=5116126
 pageID: 5116126
 product: Cumulus Linux
-version: 2.5 ESR
+version: '2.5 ESR'
 imgData: cumulus-linux-25esr
 siteSlug: cumulus-linux-25esr
 ---


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Let's see if the version number needs to be quoted since
it contains a space.