### PR TITLE
BGP with VRF config

### DIFF
--- a/content/cumulus-linux/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -402,6 +402,8 @@ between a pair of VRFs.
   even if their next hops become unreachable. Therefore, route leaking
   for BGP-learned routes is recommended only when they are learned
   through single-hop eBGP.
+- You cannot configure VRF instances of BGP in multiple autonomous systems
+  (AS) or an AS that is not the same as the global AS.
 - Cumulus Networks recommends that you do not use the default VRF as a
   shared service VRF. Create another VRF for shared services.
 - Broadcom switches have certain limitations when leaking routes
@@ -435,7 +437,7 @@ _false_, as that is used only for [static route leaking](#configure-static-route
     dynamically leaked into VRF `turtle`.
 
         cumulus@switch:~$ net add bgp vrf rocket autonomous-system 65001
-        cumulus@switch:~$ net add bgp vrf turtle autonomous-system 65002
+        cumulus@switch:~$ net add bgp vrf turtle autonomous-system 65001
         cumulus@switch:~$ net add bgp vrf turtle ipv4 unicast import vrf rocket
         cumulus@switch:~$ net pending
         cumulus@switch:~$ net commit
@@ -445,17 +447,32 @@ file. For example:
 
     cumulus@leaf01:~$ sudo cat /etc/frr/frr.conf
     ...
-    router bgp 65001 vrf rocket
+
+   cumulus@leaf01:mgmt:~$ sudo cat /etc/frr/frr.conf
+   frr version 7.0+cl4u1
+   frr defaults datacenter
+   hostname leaf01
+   log syslog informational
+   service integrated-vtysh-config
+   !
+   router bgp 65001 vrf rocket
     !
-    router bgp 65002 vrf turtle
-     !
-      address-family ipv4 unicast
-       import vrf rocket
-      exit-address-family
-     !
-    router bgp 65002
+    address-family l2vpn evpn
+    exit-address-family
+   !
+   router bgp 65001 vrf turtle
     !
-    ...
+    address-family ipv4 unicast
+     import vrf rocket
+    exit-address-family
+    !
+    address-family l2vpn evpn
+    exit-address-family
+   !
+   router bgp 65001
+   !
+   line vty
+   !
 
 #### Exclude Certain Prefixes
 


### PR DESCRIPTION
Ticket: UD-1731
Reviewed By:
Testing Done:

BGP with VRFs can only use the global AS; fixed configs