### PR TITLE
Fix VRRP preempt mode syntax

### DIFF
--- a/content/cumulus-linux/Layer-2/Virtual-Router-Redundancy-VRR-and-VRRP.md
+++ b/content/cumulus-linux/Layer-2/Virtual-Router-Redundancy-VRR-and-VRRP.md
@@ -492,7 +492,7 @@ You can also set these optional parameters. If you do not set these parameters, 
 | ------------------- | ------------- | ----------- |
 | `priority` | 100 | The priority level of the virtual router within the virtual router group, which determines the role that each virtual router plays and what happens if the master fails. Virtual routers have a priority between 1 and 254; the router with the highest priority becomes the master. |
 | `advertisement interval` | 1000 milliseconds | The advertisement interval is the interval between successive advertisements by the master in a virtual router group. You can specify a value between 10 and 40950. |
-| `preempt` | enabled | Preempt mode lets the router take over as master for a virtual router group if it has a higher priority than the current master. Preempt mode is enabled by default. To disable preempt mode, you need to edit the `/etc/frr/frr.conf` file and add the line `vrrp <VRID> preempt no` to the interface stanza, then restart FRR service. |
+| `preempt` | enabled | Preempt mode lets the router take over as master for a virtual router group if it has a higher priority than the current master. Preempt mode is enabled by default. To disable preempt mode, you need to edit the `/etc/frr/frr.conf` file and add the line `no vrrp <VRID> preempt` to the interface stanza, then restart FRR service. |
 
 The NCLU commands write VRRP configuration to the `/etc/network/interfaces` file and the `/etc/frr/frr.conf` file.
 


### PR DESCRIPTION
Ticket: UD-1743
Reviewed By:
Testing Done:

`no vrrp VRID preempt` is correct.