### PR TITLE
Replace Cloudfront links with docs-cdn

### DIFF
--- a/content/cumulus-linux/_index.md
+++ b/content/cumulus-linux/_index.md
@@ -30,7 +30,7 @@ get you started.
 
 ### User Guide
 A link to download the Cumulus Linux 3.7.7 Documentation User Guide is
-[here](http://dkahegywkrw3e.cloudfront.net/Cumulus_Linux_3-7-7_User_Guide.pdf).
+[here](http://docs-cdn.cumulusnetworks.com/Cumulus_Linux_3-7-7_User_Guide.pdf).
 
 ### What's New in this Release?
 

--- a/content/cumulus-netq/More-Documents/PDFs.md
+++ b/content/cumulus-netq/More-Documents/PDFs.md
@@ -12,10 +12,10 @@ The following Cumulus NetQ user documentation is available in PDF for offline vi
 
 NetQ 2.3.0
 
-- [Cumulus NetQ Deployment Guide PDF](https://dkahegywkrw3e.cloudfront.net/pdfs/Cumulus-NetQ-Deployment-Guide-230.pdf)
-- [Cumulus NetQ Integration Guide PDF](https://dkahegywkrw3e.cloudfront.net/pdfs/Cumulus-NetQ-Integration-Guide-230.pdf)
-- [Cumulus NetQ UI User Guide PDF](https://dkahegywkrw3e.cloudfront.net/pdfs/Cumulus-NetQ-UI-User-Guide-230.pdf)
-- [Cumulus NetQ CLI User Guide PDF](https://dkahegywkrw3e.cloudfront.net/pdfs/Cumulus-NetQ-CLI-User-Guide-230.pdf)
+- [Cumulus NetQ Deployment Guide PDF](https://docs-cdn.cumulusnetworks.com/pdfs/Cumulus-NetQ-Deployment-Guide-230.pdf)
+- [Cumulus NetQ Integration Guide PDF](https://docs-cdn.cumulusnetworks.com/pdfs/Cumulus-NetQ-Integration-Guide-230.pdf)
+- [Cumulus NetQ UI User Guide PDF](https://docs-cdn.cumulusnetworks.com/pdfs/Cumulus-NetQ-UI-User-Guide-230.pdf)
+- [Cumulus NetQ CLI User Guide PDF](https://docs-cdn.cumulusnetworks.com/pdfs/Cumulus-NetQ-CLI-User-Guide-230.pdf)
 
 {{%notice note%}}
 


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Update static links to Cloudfront with links to docs-cdn.