### PR TITLE
Fix link to campus arch guide

### DIFF
--- a/content/cumulus-linux/Network-Solutions/Campus.md
+++ b/content/cumulus-linux/Network-Solutions/Campus.md
@@ -28,4 +28,4 @@ deployment:
 
 ## More Information
 
-For a deep dive into campus architecture, read the [campus architecture solution guide](/guides/campus-architecture-guide).
+For a deep dive into campus architecture, read the [campus architecture solution guide](/guides/campus-architecture-guide/).


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Link was missing the trailing slash.