### PR TITLE
Missing / in quick start URL

### DIFF
--- a/themes/netDocs/layouts/home.html
+++ b/themes/netDocs/layouts/home.html
@@ -79,7 +79,7 @@
             <p class="small">An open network operating system designed for efficiency, automation and scale</p>
             <ul>
               <li><a href="/cumulus-linux/">User guide</a></li>
-              <li><a href="/cumulus-linux/Quick-Start-Guide">Quick start guide</a></li>
+              <li><a href="/cumulus-linux/Quick-Start-Guide/">Quick start guide</a></li>
             </ul>
           </div>
           <div class="col-12 col-sm-6 col-lg-4 mb-5 mb-lg-0">


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Quick start URL redirects to the landing page since it's not formatted correctly.