### PR TITLE
hal.bcm.per_vlan_router_mac_lookup for external hyperloop only

### DIFF
--- a/content/version/cumulus-linux-332/Network-Virtualization/VXLAN-Hyperloop.md
+++ b/content/version/cumulus-linux-332/Network-Virtualization/VXLAN-Hyperloop.md
@@ -210,6 +210,9 @@ II switch to a configurable 512 local IP addresses (SVIs and so forth),
 so you should use this only as a last resort. This is only a limitation
 on this specific ASIC type.
 
+The `hal.bcm.per_vlan_router_mac_lookup` option is meant only for external
+hyperloops. This option is not recommended for any other purpose or use case.
+
 {{%/notice%}}
 
 ## VXLAN Hyperloop Troubleshooting Matrix

--- a/content/version/cumulus-linux-343/Network-Virtualization/VXLAN-Hyperloop.md
+++ b/content/version/cumulus-linux-343/Network-Virtualization/VXLAN-Hyperloop.md
@@ -201,6 +201,9 @@ II switch to a configurable 512 local IP addresses (SVIs and so forth),
 so you should use this only as a last resort. This is only a limitation
 on this specific ASIC type.
 
+The `hal.bcm.per_vlan_router_mac_lookup` option is meant only for external
+hyperloops. This option is not recommended for any other purpose or use case.
+
 {{%/notice%}}
 
 ## VXLAN Hyperloop Troubleshooting Matrix

--- a/content/version/cumulus-linux-35/Network-Virtualization/VXLAN-Routing.md
+++ b/content/version/cumulus-linux-35/Network-Virtualization/VXLAN-Routing.md
@@ -261,6 +261,9 @@ II switch to a configurable 512 local IP addresses (SVIs and so on). Use
 this only as a last resort. This is only a limitation on this specific
 ASIC.
 
+The `hal.bcm.per_vlan_router_mac_lookup` option is meant only for external
+hyperloops. This option is not recommended for any other purpose or use case.
+
 {{%/notice%}}
 
 ## VXLAN Routing Data Plane and the Mellanox Spectrum Platform

--- a/content/version/cumulus-linux-36/Network-Virtualization/VXLAN-Routing.md
+++ b/content/version/cumulus-linux-36/Network-Virtualization/VXLAN-Routing.md
@@ -258,6 +258,9 @@ Setting `hal.bcm.per_vlan_router_mac_lookup = TRUE` limits the Trident
 II switch to a configurable 512 local IP addresses (SVIs and so on). Use
 this only as a last resort. This is only a limitation on this specific ASIC.
 
+The `hal.bcm.per_vlan_router_mac_lookup` option is meant only for external
+hyperloops. This option is not recommended for any other purpose or use case.
+
 {{%/notice%}}
 
 ## VXLAN Routing Data Plane and the Mellanox Spectrum Platform

--- a/content/version/cumulus-linux-37/Network-Virtualization/VXLAN-Routing.md
+++ b/content/version/cumulus-linux-37/Network-Virtualization/VXLAN-Routing.md
@@ -265,9 +265,12 @@ for the change to take effect.
 {{%notice warning%}}
 
 Setting `hal.bcm.per_vlan_router_mac_lookup = TRUE` limits the Trident
-II switch to a configurable 512 local IP addresses (SVIs and so on). Use
-this only as a last resort. This is only a limitation on this specific
-ASIC.
+II switch to a configurable 512 local IP addresses (SVIs and so forth),
+so you should use this only as a last resort. This is only a limitation
+on this specific ASIC type.
+
+The `hal.bcm.per_vlan_router_mac_lookup` option is meant only for external
+hyperloops. This option is not recommended for any other purpose or use case.
 
 {{%/notice%}}
 


### PR DESCRIPTION
Ticket: UD-1655
Reviewed By:
Testing Done:

The hal.bcm.per_vlan_router_mac_lookup switchd flag is only for external hyperloop; clarified that to be the case.
Since there is no external hyperloop in 4.0, no mention of this there.