### PR TITLE
Clarify VXLAN behavior with subinterfaces and SVIs, version numbers

### DIFF
--- a/content/cumulus-linux/Network-Virtualization/_index.md
+++ b/content/cumulus-linux/Network-Virtualization/_index.md
@@ -24,7 +24,7 @@ VXLAN is supported only on switches in the [Cumulus Linux HCL](http://cumulusnet
 
 {{%notice note%}}
 
-VXLAN encapsulation over layer 3 subinterfaces (for example, swp3.111) is not supported. Only configure VXLAN uplinks as layer 3 interfaces without any subinterfaces (for example, swp3).
+VXLAN encapsulation over layer 3 subinterfaces (for example, swp3.111) or SVIs is not supported as traffic transiting through the switch may get dropped; even if the subinterface is used only for underlay traffic and does not perform VXLAN encapsulation, traffic may still get dropped. Only configure VXLAN uplinks as layer 3 interfaces without any subinterfaces (for example, swp3).
 
 The VXLAN tunnel endpoints cannot share a common subnet; there must be at least one layer 3 hop between the VXLAN source and destination.
 

--- a/content/cumulus-linux/_index.md
+++ b/content/cumulus-linux/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 4.0 User Guide
 author: Cumulus Networks
 weight: -40
 aliases:

--- a/content/cumulus-netq/_index.md
+++ b/content/cumulus-netq/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus NetQ
+title: Cumulus NetQ 2.3
 author: Cumulus Networks
 weight: 1
 aliases:

--- a/content/version/cumulus-linux-25esr/_index.md
+++ b/content/version/cumulus-linux-25esr/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 2.5 ESR User Guide
 author: Cumulus Networks
 weight: -25
 aliases:

--- a/content/version/cumulus-linux-30/_index.md
+++ b/content/version/cumulus-linux-30/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.0 User Guide
 author: Cumulus Networks
 weight: -30
 aliases:
@@ -36,34 +36,12 @@ Please visit the [Cumulus Networks Web
 site](http://docs.cumulusnetworks.com) for the most up to date
 documentation.
 
-  - [Release Notes for Cumulus
-    Linux 3.0.1](https://support.cumulusnetworks.com/hc/en-us/articles/222822047)
-
-  - [What's New in Cumulus Linux
-    3.0.1](/version/cumulus-linux-30/Whats-New-in-Cumulus-Linux-3.0.1)
-
+  - [Release Notes for Cumulus Linux 3.0.1](https://support.cumulusnetworks.com/hc/en-us/articles/222822047)
+  - [What's New in Cumulus Linux 3.0.1](/version/cumulus-linux-30/Whats-New-in-Cumulus-Linux-3.0.1)
   - [Quick Start Guide](/version/cumulus-linux-30/Quick-Start-Guide)
-
-  - [Installation, Upgrading and Package
-    Management](/version/cumulus-linux-30/Installation-Upgrading-and-Package-Management/)
-
+  - [Installation, Upgrading and Package Management](/version/cumulus-linux-30/Installation-Upgrading-and-Package-Management/)
   - [System Management](/version/cumulus-linux-30/System-Management/)
-
-  - [Configuring and Managing Network
-    Interfaces](/version/cumulus-linux-30/Configuring-and-Managing-Network-Interfaces/)
-
-  - [Layer 2
-    Features](/version/cumulus-linux-30/Layer-1-and-Layer-2-Features/)
-
+  - [Configuring and Managing Network Interfaces](/version/cumulus-linux-30/Configuring-and-Managing-Network-Interfaces/)
+  - [Layer 2 Features](/version/cumulus-linux-30/Layer-1-and-Layer-2-Features/)
   - [Layer 3 Features](/version/cumulus-linux-30/Layer-3-Features/)
-
-  - [Monitoring and
-    Troubleshooting](/version/cumulus-linux-30/Monitoring-and-Troubleshooting/)
-
-<article id="html-search-results" class="ht-content" style="display: none;">
-
-</article>
-
-<footer id="ht-footer">
-
-</footer>
+  - [Monitoring and Troubleshooting](/version/cumulus-linux-30/Monitoring-and-Troubleshooting/)

--- a/content/version/cumulus-linux-31/_index.md
+++ b/content/version/cumulus-linux-31/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.1 User Guide
 author: Cumulus Networks
 weight: -31
 aliases:
@@ -30,36 +30,14 @@ Please visit the [Cumulus Networks Web
 site](http://docs.cumulusnetworks.com) for the most up to date
 documentation.
 
-  - [Release Notes for Cumulus
-    Linux 3.1.2](https://support.cumulusnetworks.com/hc/en-us/articles/231974068)
-
+  - [Release Notes for Cumulus Linux 3.1.2](https://support.cumulusnetworks.com/hc/en-us/articles/231974068)
   - [What's New in Cumulus Linux
     3.1.2](/version/cumulus-linux-31/What's-New-in-Cumulus-Linux-3.1)
-
   - [Quick Start Guide](/version/cumulus-linux-31/Quick-Start-Guide)
-
-  - [Installation, Upgrading and Package
-    Management](/version/cumulus-linux-31/Installation-Upgrading-and-Package-Management/)
-
+  - [Installation, Upgrading and Package Management](/version/cumulus-linux-31/Installation-Upgrading-and-Package-Management/)
   - [System Management](/version/cumulus-linux-31/System-Management/)
-
-  - [Configuring and Managing Network
-    Interfaces](/version/cumulus-linux-31/Configuring-and-Managing-Network-Interfaces/)
-
-  - [Layer 1 and Layer 2
-    Features](/version/cumulus-linux-31/Layer-1-and-Layer-2-Features/)
-
+  - [Configuring and Managing Network Interfaces](/version/cumulus-linux-31/Configuring-and-Managing-Network-Interfaces/)
+  - [Layer 1 and Layer 2 Features](/version/cumulus-linux-31/Layer-1-and-Layer-2-Features/)
   - [Layer 3 Features](/version/cumulus-linux-31/Layer-3-Features/)
-
-  - [Monitoring and
-    Troubleshooting](/version/cumulus-linux-31/Monitoring-and-Troubleshooting/)
-
+  - [Monitoring and Troubleshooting](/version/cumulus-linux-31/Monitoring-and-Troubleshooting/)
   - [Network Solutions](/version/cumulus-linux-31/Network-Solutions/)
-
-<article id="html-search-results" class="ht-content" style="display: none;">
-
-</article>
-
-<footer id="ht-footer">
-
-</footer>

--- a/content/version/cumulus-linux-321/_index.md
+++ b/content/version/cumulus-linux-321/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.2 User Guide
 author: Cumulus Networks
 weight: -32
 aliases:
@@ -12,7 +12,7 @@ imgData: cumulus-linux-321
 siteSlug: cumulus-linux-321
 subsection: true
 ---
-## Introducing Cumulus Linux</span>
+## Introducing Cumulus Linux
 
 Cumulus Linux is the networking industry's first full-featured Linux
 operating system. The [Debian
@@ -36,23 +36,20 @@ Read the [release
 notes](https://support.cumulusnetworks.com/hc/en-us/articles/115002201048)
 for new features and known issues in this release.
 
-### What's New in Cumulus Linux 3.2.1</span>
+### What's New in Cumulus Linux 3.2.1
 
 Cumulus Linux 3.2.1 adds these new features and platforms, including:
 
   - **Network Command Line Utility**: We've improved the syntax so it's
     even easier for network operators to configure Cumulus Linux with
     [NCLU](/version/cumulus-linux-321/System-Configuration/Network-Command-Line-Utility).
-
   - **Platform Independent Multicast (PIM)**: We've improved [multicast
     latency](/version/cumulus-linux-321/Layer-Three/Protocol-Independent-Multicast-PIM)
     on Mellanox switches.
-
   - **Explicit Congestion Notification (ECN)**: We've expanded support
     for
     [ECN](Buffer-and-Queue-Management.html#src-5127004_BufferandQueueManagement-ecn)
     to Tomahawk switches.
-
   - **New 100G platform**: Early access support for the [Edge-Core
     AS7412-32X](https://cumulusnetworks.com/HCL), which uses the
     Mellanox Spectrum ASIC.
@@ -62,7 +59,7 @@ information regarding bug fixes and known issues present in this
 release, refer to the [product release
 notes](https://support.cumulusnetworks.com/hc/en-us/articles/115002201048).
 
-### Open Source Contributions</span>
+### Open Source Contributions
 
 Cumulus Networks has forked various software projects, like CFEngine,
 `Netdev` and some Puppet Labs packages in order to implement various
@@ -75,18 +72,10 @@ applications as well.
 The list of open source projects is on the [open source
 software](http://oss.cumulusnetworks.com/) page.
 
-### Hardware Compatibility List</span>
+### Hardware Compatibility List
 
 You can find the most up to date hardware compatibility list (HCL)
 [here](http://cumulusnetworks.com/hcl/). Use the HCL to confirm that
 your switch model is supported by Cumulus Networks. The HCL is updated
 regularly, listing products by port configuration, manufacturer, and SKU
 part number.
-
-<article id="html-search-results" class="ht-content" style="display: none;">
-
-</article>
-
-<footer id="ht-footer">
-
-</footer>

--- a/content/version/cumulus-linux-332/_index.md
+++ b/content/version/cumulus-linux-332/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.3 User Guide
 author: Cumulus Networks
 weight: -33
 aliases:

--- a/content/version/cumulus-linux-343/_index.md
+++ b/content/version/cumulus-linux-343/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.4 User Guide
 author: Cumulus Networks
 weight: -34
 aliases:
@@ -73,12 +73,12 @@ improvements:
   [NCLU](/version/cumulus-linux-343/System-Configuration/Network-Command-Line-Utility-NCLU)
   and the
   [OpenStack ML2 driver](/version/cumulus-linux-343/Network-Solutions/OpenStack-Neutron-ML2-and-Cumulus-Linux)
-  - [QinQ with VXLANs](/version/cumulus-linux-343/Network-Virtualization/Hybrid-Cloud-Connectivity-with-QinQ-and-VXLANs)
+- [QinQ with VXLANs](/version/cumulus-linux-343/Network-Virtualization/Hybrid-Cloud-Connectivity-with-QinQ-and-VXLANs)
     is now generally available
-  - [PIM support](/version/cumulus-linux-343/Layer-Three/Protocol-Independent-Multicast-PIM)
+- [PIM support](/version/cumulus-linux-343/Layer-Three/Protocol-Independent-Multicast-PIM)
     expanded to include virtual routing and forwarding (VRF) and
     bidirectional forwarding detection (BFD) for PIM neighbors
-  - The default [MAC ageing time](/version/cumulus-linux-343/Layer-One-and-Two/Ethernet-Bridging-VLANs/#mac-address-ageing)
+- The default [MAC ageing time](/version/cumulus-linux-343/Layer-One-and-Two/Ethernet-Bridging-VLANs/#mac-address-ageing)
     has been set to 30 minutes and the default 
     [ARP base\_reachable time](/version/cumulus-linux-343/Layer-One-and-Two/Ethernet-Bridging-VLANs/VLAN-aware-Bridge-Mode-for-Large-scale-Layer-2-Environments/#configuring-arp-timers)
     has been set to 18 minutes

--- a/content/version/cumulus-linux-35/_index.md
+++ b/content/version/cumulus-linux-35/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.5 User Guide
 author: Cumulus Networks
 weight: -35
 aliases:

--- a/content/version/cumulus-linux-36/Network-Virtualization/_index.md
+++ b/content/version/cumulus-linux-36/Network-Virtualization/_index.md
@@ -48,12 +48,9 @@ Spectrum chipset.
 
 {{%notice note%}}
 
-VXLAN encapsulation over layer 3 subinterfaces (for example, swp3.111)
-is not supported. Only configure VXLAN uplinks as layer 3 interfaces
-without any subinterfaces (for example, swp3).
+VXLAN encapsulation over layer 3 subinterfaces (for example, swp3.111) or SVIs is not supported as traffic transiting through the switch may get dropped; even if the subinterface is used only for underlay traffic and does not perform VXLAN encapsulation, traffic may still get dropped. Only configure VXLAN uplinks as layer 3 interfaces without any subinterfaces (for example, swp3).
 
-The VXLAN tunnel endpoints cannot share a common subnet; there must be
-at least one layer 3 hop between the VXLAN source and destination.
+The VXLAN tunnel endpoints cannot share a common subnet; there must be at least one layer 3 hop between the VXLAN source and destination.
 
 {{%/notice%}}
 

--- a/content/version/cumulus-linux-36/_index.md
+++ b/content/version/cumulus-linux-36/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.6 User Guide
 author: Cumulus Networks
 weight: -36
 aliases:

--- a/content/version/cumulus-linux-37/Network-Virtualization/_index.md
+++ b/content/version/cumulus-linux-37/Network-Virtualization/_index.md
@@ -49,12 +49,9 @@ Mellanox Spectrum chipset.
 
 {{%notice note%}}
 
-VXLAN encapsulation over layer 3 subinterfaces (for example, swp3.111)
-is not supported. Likewise, forwarding of transit VXLAN traffic over layer 3 subinterfaces is not supported either.  Only configure interfaces that are responsible for forwarding VXLAN traffic as either SVIs or layer 3 interfaces
-without any subinterfaces (for example, swp3).
+VXLAN encapsulation over layer 3 subinterfaces (for example, swp3.111) or SVIs is not supported as traffic transiting through the switch may get dropped; even if the subinterface is used only for underlay traffic and does not perform VXLAN encapsulation, traffic may still get dropped. Only configure VXLAN uplinks as layer 3 interfaces without any subinterfaces (for example, swp3).
 
-The VXLAN tunnel endpoints cannot share a common subnet; there must be
-at least one layer 3 hop between the VXLAN source and destination.
+The VXLAN tunnel endpoints cannot share a common subnet; there must be at least one layer 3 hop between the VXLAN source and destination.
 
 {{%/notice%}}
 

--- a/content/version/cumulus-linux-37/_index.md
+++ b/content/version/cumulus-linux-37/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus Linux User Guide
+title: Cumulus Linux 3.7 User Guide
 author: Cumulus Networks
 weight: -37
 aliases:

--- a/content/version/cumulus-netq-10/_index.md
+++ b/content/version/cumulus-netq-10/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus NetQ
+title: Cumulus NetQ 1.0
 author: Cumulus Networks
 weight: -10
 aliases:

--- a/content/version/cumulus-netq-110/_index.md
+++ b/content/version/cumulus-netq-110/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus NetQ
+title: Cumulus NetQ 1.1
 author: Cumulus Networks
 weight: -11
 aliases:

--- a/content/version/cumulus-netq-121/_index.md
+++ b/content/version/cumulus-netq-121/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus NetQ
+title: Cumulus NetQ 1.2
 author: Cumulus Networks
 weight: -12
 aliases:

--- a/content/version/cumulus-netq-141/_index.md
+++ b/content/version/cumulus-netq-141/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus NetQ
+title: Cumulus NetQ 1.4
 author: Cumulus Networks
 weight: -14
 aliases:

--- a/content/version/cumulus-netq-21/_index.md
+++ b/content/version/cumulus-netq-21/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus NetQ User Docs
+title: Cumulus NetQ 2.1 User Docs
 author: Cumulus Networks
 weight: -18
 aliases:

--- a/content/version/cumulus-netq-22/_index.md
+++ b/content/version/cumulus-netq-22/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Cumulus NetQ
+title: Cumulus NetQ 2.2
 author: Cumulus Networks
 weight: -22
 product: Cumulus NetQ


### PR DESCRIPTION
Ticket: UD-1770
Reviewed By:
Testing Done:

VXLAN traffic can only go over swps, not subinterfaces or SVIs
Add version number to left side TOC for CL and NetQ