### PR TITLE
Add warning about NCLU and Mako templates

### DIFF
--- a/content/cumulus-linux/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/_index.md
+++ b/content/cumulus-linux/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/_index.md
@@ -872,9 +872,15 @@ iface br1
 
  </details>
 
-## Use Templates
+## Mako Templates
 
 `ifupdown2` supports [Mako-style templates](http://www.makotemplates.org/). The Mako template engine is run over the `interfaces` file before parsing.
+
+{{%notice warning%}}
+
+While `ifupdown2` supports Mako templates, NCLU does not understand them. As a result, NCLU cannot read or write to the `/etc/network/interfaces` file.
+
+{{%/notice%}}
 
 Use the template to declare cookie-cutter bridges in the `interfaces` file:
 

--- a/content/version/cumulus-linux-37/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/_index.md
+++ b/content/version/cumulus-linux-37/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/_index.md
@@ -716,10 +716,15 @@ These commands produce the following snippet in the
     auto swp12
     iface swp12
 
-## Use Templates
+## Mako Templates
 
-`ifupdown2` supports [Mako-style templates](http://www.makotemplates.org/).
-The Mako template engine is run over the `interfaces` file before parsing.
+`ifupdown2` supports [Mako-style templates](http://www.makotemplates.org/). The Mako template engine is run over the `interfaces` file before parsing.
+
+{{%notice warning%}}
+
+While `ifupdown2` supports Mako templates, NCLU does not understand them. As a result, NCLU cannot read or write to the `/etc/network/interfaces` file.
+
+{{%/notice%}}
 
 Use the template to declare cookie-cutter bridges in the `interfaces`
 file:


### PR DESCRIPTION
Ticket: UD-914
Reviewed By:
Testing Done:

NCLU can't be used with Mako templates.