### PR TITLE
template whitespace adjustments creating 10x reduction in html lines

### DIFF
--- a/themes/netDocs/layouts/_default/baseof.html
+++ b/themes/netDocs/layouts/_default/baseof.html
@@ -119,16 +119,16 @@
             v{{.Page.Params.version}}
           </button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-            {{range where .Site.Sections "Params.product" $currentProduct}}
-            <a class = "dropdown-item" href = "{{ .RelPermalink }}"> v{{.Params.version}}</a>
-            {{ end }}
-            {{range where .Site.Pages "Section" "version"}}
-             {{ if eq .Params.product $currentProduct }}
-             {{ if .Params.subsection}}
-            <a class = "dropdown-item" href = "{{ .RelPermalink }}"> v{{.Params.version}}</a>
-            {{ end }}
-            {{ end }}
-            {{ end }}
+            {{- range where .Site.Sections "Params.product" $currentProduct -}}
+            <a class = "dropdown-item" href = "{{- .RelPermalink -}}"> v{{- .Params.version -}}</a>
+            {{- end -}}
+            {{- range where .Site.Pages "Section" "version" -}}
+             {{- if eq .Params.product $currentProduct -}}
+             {{- if .Params.subsection -}}
+            <a class = "dropdown-item" href = "{{- .RelPermalink -}}"> v{{- .Params.version -}}</a>
+            {{- end -}}
+            {{- end -}}
+            {{- end -}}
           </div>
       </div>
     </div>
@@ -162,19 +162,19 @@
         <div class="version-dropdown">
           <div id="dropdown" class="dropdown">
             <button class="btn" type="button" id="dropdownMenuButton">
-              v{{.Page.Params.version}}
+              v{{- .Page.Params.version -}}
             </button>
             <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-              {{range where .Site.Sections "Params.product" $currentProduct}}
-              <a class = "dropdown-item" href = "{{ .RelPermalink }}"> v{{.Params.version}}</a>
-              {{ end }}
-              {{range where .Site.Pages "Section" "version"}}
-               {{ if eq .Params.product $currentProduct }}
-               {{ if .Params.subsection}}
-              <a class = "dropdown-item" href = "{{ .RelPermalink }}"> v{{.Params.version}}</a>
-              {{ end }}
-              {{ end }}
-              {{ end }}
+              {{- range where .Site.Sections "Params.product" $currentProduct -}}
+              <a class = "dropdown-item" href = "{{- .RelPermalink -}}"> v{{- .Params.version -}}</a>
+              {{- end -}}
+              {{- range where .Site.Pages "Section" "version" -}}
+               {{- if eq .Params.product $currentProduct -}}
+               {{- if .Params.subsection -}}
+              <a class = "dropdown-item" href = "{{ .RelPermalink }}"> v{{- .Params.version -}}</a>
+              {{- end -}}
+              {{- end -}}
+              {{- end -}}
             </div>
           </div> <!-- version dropdown -->
         </div>
@@ -437,3 +437,4 @@
 </body>
 
 </html>
+

--- a/themes/netDocs/layouts/partials/docs/menu-filetree.html
+++ b/themes/netDocs/layouts/partials/docs/menu-filetree.html
@@ -24,13 +24,13 @@
 {{ define "book-section" }}
 {{ with .Section }}
   <li {{ if .Params.bookFlatSection}} class="book-section-flat" {{ end }}>
-    {{ if .Content }}
-      {{ template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}
-    {{ else }}
+    {{- if .Content }}
+      {{- template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}
+    {{- else }}
       <span>{{ template "title" . }}</span>
     {{ end }}
 
-    {{ template "book-section-children" (dict "Section" . "CurrentPage" $.CurrentPage) }}
+    {{- template "book-section-children" (dict "Section" . "CurrentPage" $.CurrentPage) }}
   </li>
 {{ end }}
 {{ end }}
@@ -57,3 +57,4 @@
   </a>
 {{ end }}
 {{ end }}
+

--- a/themes/netDocs/layouts/partials/docs/menu-sectiontree
+++ b/themes/netDocs/layouts/partials/docs/menu-sectiontree
@@ -20,13 +20,9 @@
 {{ define "book-section-children" }}
 {{ with .Section }}
   <ul id = subsection class="cn-book-section-container">
-    {{ range .Sections }}
-      {{ template "book-section" (dict "Section" . "CurrentPage" $.CurrentPage ) }}
-    {{ end }}
+    {{ range .Sections }}{{ template "book-section" (dict "Section" . "CurrentPage" $.CurrentPage ) }}{{ end }}
     {{ range .Pages }}
-    <li >
-      {{ template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}
-    </li>
+    <li >{{ template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}</li>
     {{ end }}
   </ul>
 {{ end }}
@@ -34,9 +30,7 @@
 
 {{ define "book-page-link" }}
 {{ with .Page }}
-  <a href="{{ .RelPermalink }}" {{ if eq $.CurrentPage .Permalink }} class="active" {{ end }}>
-    {{ .Title }}
-  </a>
+  <a href="{{ .RelPermalink }}" {{ if eq $.CurrentPage .Permalink }} class="active" {{ end }}>{{ .Title }}</a>
+{{ end }}
+{{ end }}
 
-{{ end }}
-{{ end }}

--- a/themes/netDocs/layouts/partials/docs/menu-subsectiontree
+++ b/themes/netDocs/layouts/partials/docs/menu-subsectiontree
@@ -12,34 +12,31 @@
   </ul>
 
 {{ define "book-section" }}
-{{ with .Section }}
+{{- with .Section }}
   <li class="cn-book-section">
-      {{ template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}
+      {{- template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) -}}
 
-      {{ template "book-section-children" (dict "Section" . "CurrentPage" $.CurrentPage ) }}
+      {{- template "book-section-children" (dict "Section" . "CurrentPage" $.CurrentPage ) }}
   </li>
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}
 
 {{ define "book-section-children" }}
-{{ with .Section }}
+{{- with .Section -}}
   <ul class="cn-book-section-container" id = "subsection">
-    {{ range .Sections }}
-      {{ template "book-section" (dict "Section" . "CurrentPage" $.CurrentPage ) }}
-    {{ end }}
-    {{ range .Pages }}
-    <li >
-      {{ template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}
-    </li>
-    {{ end }}
+    {{- range .Sections }}
+      {{- template "book-section" (dict "Section" . "CurrentPage" $.CurrentPage ) }}
+    {{- end }}
+    {{- range .Pages -}}
+    <li>{{- template "book-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}</li>
+{{- end -}}
   </ul>
+{{- end }}
+{{- end -}}
+
+{{ define "book-page-link" }}
+{{- with .Page -}}
+  <a href="{{ .RelPermalink }}" {{ if eq $.CurrentPage .Permalink }} class="active" {{ end }}>{{ .Title }}</a>
 {{ end }}
 {{ end }}
 
-{{ define "book-page-link" }}
-{{ with .Page }}
-  <a href="{{ .RelPermalink }}" {{ if eq $.CurrentPage .Permalink }} class="active" {{ end }}>
-    {{ .Title }}
-  </a>
-{{ end }}
-{{ end }}


### PR DESCRIPTION
The existing template leaves a lot of blank lines around every line generated for the version menu and other components. This results in the CL user doc page being ~11k lines. 

By using `{{- -}}` we remove extra line returns. A few lines I also collapsed into a single line to also reduce whitespace.

Updated HTML lines are ~800