### PR TITLE
Move RN-1409 to bonding chapter

### DIFF
--- a/content/cumulus-linux/Layer-2/Bonding-Link-Aggregation.md
+++ b/content/cumulus-linux/Layer-2/Bonding-Link-Aggregation.md
@@ -256,6 +256,10 @@ Slave queue ID: 0
 
 </details>
 
+{{%notice info%}}
+The detailed output in `/proc/net/bonding/<filename>` includes the actor/partner LACP information. This information is not necessary and requires you to use `sudo` to view the file.
+{{%/notice%}}
+
 ## Caveats and Errata
 
 - An interface cannot belong to multiple bonds.

--- a/content/version/cumulus-linux-37/Layer-2/Bonding-Link-Aggregation.md
+++ b/content/version/cumulus-linux-37/Layer-2/Bonding-Link-Aggregation.md
@@ -396,6 +396,7 @@ address traffic to the bond.
 - A bond can have subinterfaces, but subinterfaces cannot have a bond.
 - A bond cannot enslave VLAN subinterfaces.
 - Set all slave ports within a bond to the same speed/duplex and make sure they match the link partner's slave ports.
+- The detailed output in `/proc/net/bonding/<filename>` includes the actor/partner LACP information. This information is not necessary and requires you to use `sudo` to view the file.
 - On a [Cumulus RMP](/cumulus-rmp/) switch, if you create a bond with multiple 10G member ports, traffic gets dropped when the bond uses members of the same *unit* listed in the `/var/lib/cumulus/porttab` file. For example, traffic gets dropped if both swp49 and swp52 are in the bond because they both are in the xe0 unit (or if both swp50 and swp51 are in the same bond because they are both in xe1):  
 swp49 xe0 0 0 -1 0  
 swp50 xe1 0 0 -1 0  


### PR DESCRIPTION
Ticket: RN-1409
Reviewed By:
Testing Done:

Move release note about output in /proc/net/bonding/FILE to the LACP chapter since it's expected behavior.