### PR TITLE
Update CSS for CC icon

### DIFF
--- a/themes/netDocs/assets/custom.scss
+++ b/themes/netDocs/assets/custom.scss
@@ -1345,7 +1345,7 @@ footer {
         justify-items: flex-start;
       }
 
-      img {
+      img#rt-icon {
         max-width: 50px;
         margin: 0 auto;
         @media #{$lg-up} {

--- a/themes/netDocs/layouts/_default/baseof.html
+++ b/themes/netDocs/layouts/_default/baseof.html
@@ -262,7 +262,7 @@
         <div class="col-12">
           <div class="footer-content">
             <div class="mb-4">
-                <img src="https://static.cumulusnetworks.com/static/images/shared/cumulus-networks-rt-white-trademarked.ff839f1b2570.svg">
+                <img id="rt-icon" src="https://static.cumulusnetworks.com/static/images/shared/cumulus-networks-rt-white-trademarked.ff839f1b2570.svg">
                 <p>© <script type="text/javascript">document.write(new Date().getFullYear());</script> Cumulus Networks.<br>
                 Site by <a href="//unomena.com/" target="_blank">Unomena</a>.</p>
                 <p><a href="/license/"><img src="https://docs-cdn.cumulusnetworks.com/images/by-nc-sa.svg" alt="Cumulus Networks CC-by-NC-SA License"></a></p>

--- a/themes/netDocs/layouts/home.html
+++ b/themes/netDocs/layouts/home.html
@@ -199,7 +199,7 @@
           <div class="col-12">
             <div class="footer-content">
               <div class="mb-4">
-                  <img src="https://static.cumulusnetworks.com/static/images/shared/cumulus-networks-rt-white-trademarked.ff839f1b2570.svg">
+                  <img id="rt-icon" src="https://static.cumulusnetworks.com/static/images/shared/cumulus-networks-rt-white-trademarked.ff839f1b2570.svg">
                   <p>© <script type="text/javascript">document.write(new Date().getFullYear());</script> Cumulus Networks.<br>
                   Site by <a href="//unomena.com/" target="_blank">Unomena</a>.</p>
                   <p><a href="/license/"><img src="https://docs-cdn.cumulusnetworks.com/images/by-nc-sa.svg" alt="Cumulus Networks CC-by-NC-SA License"></a></p>

--- a/themes/netDocs/layouts/search/search.html
+++ b/themes/netDocs/layouts/search/search.html
@@ -88,9 +88,10 @@
           <div class="col-12">
             <div class="footer-content">
               <div class="mb-4">
-                  <img src="https://static.cumulusnetworks.com/static/images/shared/cumulus-networks-rt-white-trademarked.ff839f1b2570.svg">
+                  <img id="rt-icon" src="https://static.cumulusnetworks.com/static/images/shared/cumulus-networks-rt-white-trademarked.ff839f1b2570.svg">
                   <p>© <script type="text/javascript">document.write(new Date().getFullYear());</script> Cumulus Networks.<br>
                   Site by <a href="//unomena.com/" target="_blank">Unomena</a>.</p>
+                  <p><a href="/license/"><img src="https://docs-cdn.cumulusnetworks.com/images/by-nc-sa.svg" alt="Cumulus Networks CC-by-NC-SA License"></a></p>
               </div>
               <ul class="mb-4">
                 <li><h4>Products</h4></li>


### PR DESCRIPTION
Ticket:
Reviewed By: robert
Testing Done:

CSS for the rocket turtle logo clashed with the CC-by-NC-SA icon width, causing it to be too narrrow. This fixes that. Also, the search page didn't have the license icon; now it does.