### PR TITLE
Add apt key and organize cloud v on-prem commands

### DIFF
--- a/content/cumulus-netq/Cumulus-NetQ-Deployment-Guide/Install-NetQ/Install-NetQ-Agents-and-CLI-on-CL.md
+++ b/content/cumulus-netq/Cumulus-NetQ-Deployment-Guide/Install-NetQ/Install-NetQ-Agents-and-CLI-on-CL.md
@@ -11,10 +11,6 @@ After installing or upgrading your Cumulus NetQ software, you should install the
 
 This topic describes how to install and configure the NetQ Agent and CLI on Cumulus Linux switches. If you are upgrading, you can skip some of the steps which do not need to be performed a second time.
 
-{{%notice note%}}
-You only need to install the NetQ Agent on switches running Cumulus Linux 3.3.2-3.3.x or on switches running Cumulus Linux 4.0.x that have an older version of the Agent pre-installed. For switches running Cumulus Linux 4.x and the latest NetQ Agent, you can skip to the configuration topics. Check the version of the NetQ Agent on your switch using the `netq show cl-pkg-info` command.
-{{%/notice%}}
-
 ## Prepare for Installation
 
 To install the NetQ Agent you need to install the OS-specific meta package, `cumulus-netq`, on each switch. The meta package contains the NetQ Agent and CLI.
@@ -29,16 +25,35 @@ Edit the `/etc/apt/sources.list` file to add the repository for Cumulus NetQ.
 
 *Note that NetQ has a separate repository from Cumulus Linux.*
 
+{{< tabs "uniqueid" >}}
+{{< tab "Cumulus Linux 3.x" >}} 
+```
+cumulus@switch:~$ sudo nano /etc/apt/sources.list
+...
+deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 netq-2.4
+...
+```
+{{< /tab >}}
+{{< tab "Cumulus Linux 4.x" >}}
 ```
 cumulus@switch:~$ sudo nano /etc/apt/sources.list
 ...
 deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-4 netq-2.4
 ...
 ```
+{{< /tab >}}
+
+{{< /tabs >}}
 
 {{%notice tip%}}
 The repository `deb http://apps3.cumulusnetworks.com/repos/deb     CumulusLinux-4 netq-latest` can be used if you want to always retrieve the latest posted version of NetQ.
 {{%/notice%}}
+
+### Add the Apt Repository Key (Cumulus Linux 4.0 Only)
+
+Add the `apps3.cumulusnetworks.com` authentication key to Cumulus Linux.
+
+        cumulus@switch:~$ wget -qO - https://apps3.cumulusnetworks.com/setup/cumulus-apps-deb.pubkey | sudo apt-key add -
 
 ## Install NetQ Agent and CLI
 
@@ -78,9 +93,9 @@ Two methods are available for configuring the NetQ CLI on a switch:
 - Edit the configuration file on the switch, or
 - Configure and run NetQ CLI commands on the switch.
 
-### Configure NetQ CLI Using the CLI
-
 *Note that the steps to install the CLI are different depending on whether the NetQ software has been installed for an on-premises or cloud deployment.*
+
+### Configure NetQ CLI for on-premises deployments
 
 Configuring the CLI for *on-premises* deployments requires only two commands:
 
@@ -88,6 +103,8 @@ Configuring the CLI for *on-premises* deployments requires only two commands:
 netq config add cli server <ip-address-of-netq-server-or-appliance>
 netq config restart cli
 ```
+
+### Configure NetQ CLI for cloud deployments
 
 Configuring the CLI for *cloud* deployments also only requires two commands; however, there are a couple of additional options that you can apply:
 

--- a/content/cumulus-netq/Cumulus-NetQ-Deployment-Guide/Install-NetQ/Install-NetQ-Agents-and-CLI-on-CL.md
+++ b/content/cumulus-netq/Cumulus-NetQ-Deployment-Guide/Install-NetQ/Install-NetQ-Agents-and-CLI-on-CL.md
@@ -25,35 +25,38 @@ Edit the `/etc/apt/sources.list` file to add the repository for Cumulus NetQ.
 
 *Note that NetQ has a separate repository from Cumulus Linux.*
 
-{{< tabs "uniqueid" >}}
-{{< tab "Cumulus Linux 3.x" >}} 
+<details><summary>Cumulus Linux 3.x</summary>
 ```
 cumulus@switch:~$ sudo nano /etc/apt/sources.list
 ...
 deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 netq-2.4
 ...
 ```
-{{< /tab >}}
-{{< tab "Cumulus Linux 4.x" >}}
+
+{{%notice tip%}}
+The repository `deb http://apps3.cumulusnetworks.com/repos/deb     CumulusLinux-3 netq-latest` can be used if you want to always retrieve the latest posted version of NetQ.
+{{%/notice%}}
+</details>
+
+<details><summary>Cumulus Linux 4.x</summary>
 ```
 cumulus@switch:~$ sudo nano /etc/apt/sources.list
 ...
 deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-4 netq-2.4
 ...
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
 
 {{%notice tip%}}
 The repository `deb http://apps3.cumulusnetworks.com/repos/deb     CumulusLinux-4 netq-latest` can be used if you want to always retrieve the latest posted version of NetQ.
 {{%/notice%}}
+</details>
+
 
 ### Add the Apt Repository Key (Cumulus Linux 4.0 Only)
 
 Add the `apps3.cumulusnetworks.com` authentication key to Cumulus Linux.
 
-        cumulus@switch:~$ wget -qO - https://apps3.cumulusnetworks.com/setup/cumulus-apps-deb.pubkey | sudo apt-key add -
+    cumulus@switch:~$ wget -qO - https://apps3.cumulusnetworks.com/setup/cumulus-apps-deb.pubkey | sudo apt-key add -
 
 ## Install NetQ Agent and CLI
 
@@ -82,9 +85,9 @@ A simple process installs the NetQ Agent on a Cumulus switch.
 
         cumulus@switch:~$ sudo systemctl restart rsyslog.service
 
-4. Continue with [Configure Your NetQ Agents](#configure-your-netq-agents).
+<!-- 4. Continue with [Configure Your NetQ Agents](#configure-your-netq-agents). -->
 
-5. Validate NetQ Agent operation......
+<!-- 5. Validate NetQ Agent operation...... -->
 
 ## Configure the NetQ CLI
 
@@ -95,7 +98,7 @@ Two methods are available for configuring the NetQ CLI on a switch:
 
 *Note that the steps to install the CLI are different depending on whether the NetQ software has been installed for an on-premises or cloud deployment.*
 
-### Configure NetQ CLI for on-premises deployments
+<details><summary>Configure NetQ CLI for on-premises deployments</summary>
 
 Configuring the CLI for *on-premises* deployments requires only two commands:
 
@@ -103,8 +106,9 @@ Configuring the CLI for *on-premises* deployments requires only two commands:
 netq config add cli server <ip-address-of-netq-server-or-appliance>
 netq config restart cli
 ```
+</details>
 
-### Configure NetQ CLI for cloud deployments
+<details><summary>Configure NetQ CLI for cloud deployments</summary>
 
 Configuring the CLI for *cloud* deployments also only requires two commands; however, there are a couple of additional options that you can apply:
 
@@ -113,7 +117,8 @@ Configuring the CLI for *cloud* deployments also only requires two commands; how
     - save your access credentials in a file and reference that file here to simplify the configuration commands
     - specify which premises you want to query
 
-#### For Switches with Internet Access
+
+<details><summary>For Switches with Internet Access</summary>
 
 Run the following commands, being sure to replace the key values with your generated keys.
 
@@ -147,8 +152,9 @@ Updated cli server api.netq.cumulusnetworks.com vrf default port 443. Please res
 $ netq config restart cli
 Restarting NetQ CLI... Success!
 ```
+</details>
 
-#### For Switches without Internet Access
+<details><summary>For Switches without Internet Access</summary>
 
 You can use the CLI proxy that is part of the NetQ Cloud Server or Appliance with NetQ 2.2.2 and later to manage CLI access on your nodes. To make use of the proxy, you must point each switch or host to the NetQ Cloud Server or Appliance. Run the following commands, using the IP address of the proxy:
 
@@ -159,6 +165,8 @@ Updated cli server <proxy-ip-addr> vrf default port 443. Please restart netqd (n
 $ netq config restart cli
 Restarting NetQ CLI... Success!
 ```
+</details>
+</details>
 
 ## Configure Your NetQ Agents
 


### PR DESCRIPTION
This PR corrects the repo directory for CL3 vs CL4 as well as provides instructions for installing the APT key for CL4.

I've also done a bit of housekeeping to organize the cloud v on-prem steps as well as hid some incomplete instructions. 