### PR TITLE
Why specify a backup link in MLAG

### DIFF
--- a/content/cumulus-linux/Layer-2/Multi-Chassis-Link-Aggregation-MLAG.md
+++ b/content/cumulus-linux/Layer-2/Multi-Chassis-Link-Aggregation-MLAG.md
@@ -922,7 +922,9 @@ cumulus@switch:~$ net show bridge link
 
 ### Specify a Backup Link
 
-You can specify a backup link for your peer links in case the peer link goes down. When this happens, the `clagd` service uses the backup link to check the health of the peer switch.
+You should specify a backup link for your peer links in case the peer link goes down. When this happens, the `clagd` service uses the backup link to check the health of the peer switch. The backup link is specified in the `clagd-backup-ip` parameter.
+
+In an anycast VTEP environment, if you do not specify the `clagd-backup-ip` parameter, large convergence times (around 5 minutes) can result when the primary MLAG switch is powered off. Then the secondary switch must wait until the reload delay timer expires (which defaults to 300 seconds, or 5 minutes) before bringing up a VNI with its unique loopback IP.
 
 The backup IP address **must** be different than the peer link IP address (`clagd-peer-ip`). It must be reachable by a route that does not use the peer link and it must be in the same network namespace as the peer link IP address.
 

--- a/content/version/cumulus-linux-37/Layer-2/Multi-Chassis-Link-Aggregation-MLAG.md
+++ b/content/version/cumulus-linux-37/Layer-2/Multi-Chassis-Link-Aggregation-MLAG.md
@@ -1143,10 +1143,11 @@ cumulus@switch:~$ net show bridge link swp1
 
 ### Specify a Backup Link
 
-You can specify a backup link for your peer links in case the peer link
-goes down. When this happens, the `clagd` service uses the backup link
-to check the health of the peer switch. To configure a backup link, add
-`clagd-backup-ip <ADDRESS>` to the peer link configuration:
+You should specify a backup link for your peer links in case the peer link goes down. When this happens, the `clagd` service uses the backup link to check the health of the peer switch. The backup link is specified in the `clagd-backup-ip` parameter.
+
+In an anycast VTEP environment, if you do not specify the `clagd-backup-ip` parameter, large convergence times (around 5 minutes) can result when the primary MLAG switch is powered off. Then the secondary switch must wait until the reload delay timer expires (which defaults to 300 seconds, or 5 minutes) before bringing up a VNI with its unique loopback IP.
+
+To configure a backup link, add `clagd-backup-ip <ADDRESS>` to the peer link configuration:
 
 ```
 cumulus@spine01:~$ net add interface peerlink.4094 clag backup-ip 192.0.2.50


### PR DESCRIPTION
Ticket: UD-1508
Reviewed By:
Testing Done:

Long convergence times can result in an anycast VTEP environment if the backup IP isn't set and the primary MLAG switch goes down.