### PR TITLE
Quick start, VXLAN routing updates

### DIFF
--- a/content/cumulus-linux/Network-Virtualization/VXLAN-Routing.md
+++ b/content/cumulus-linux/Network-Virtualization/VXLAN-Routing.md
@@ -100,6 +100,10 @@ VXLAN routing with internal loopback is supported only with [VLAN-aware bridges]
 
 {{%/notice%}}
 
+## VXLAN Routing Data Plane and Broadcom Trident II Platforms
+
+VXLAN routing is not supported on Trident II switches, and the external hyperloop workaround for RIOT on Trident II switches has been removed in Cumulus Linux 4.0.0. Cumulus Networks recommends you use native VXLAN routing platforms and EVPN for network virtualization.
+
 ## VXLAN Routing Data Plane and the Mellanox Spectrum ASIC
 
 There is no special configuration required for VXLAN routing on the Mellanox Spectrum ASIC.

--- a/content/cumulus-linux/Quick-Start-Guide/_index.md
+++ b/content/cumulus-linux/Quick-Start-Guide/_index.md
@@ -444,10 +444,11 @@ cumulus@switch:~$ net pending
 cumulus@switch:~$ net commit
 ```
 
-To add an IP address to a bridge interface, you must put it into a VLAN interface:
+To add an IP address to a bridge interface, you must put it into a VLAN interface and set the bridge PVID:
 
 ```
 cumulus@switch:~$ net add vlan 100 ip address 10.2.2.1/24
+cumulus@switch:~$ net add bridge bridge pvid 100
 cumulus@switch:~$ net pending
 cumulus@switch:~$ net commit
 ```
@@ -466,13 +467,14 @@ iface swp1
   address 10.1.1.1/30
 ```
 
-To add an IP address to a bridge interface, include the address under the `iface` stanza in the `/etc/network/interfaces` file:
+To add an IP address to a bridge interface, include the address and PVID under the `iface` stanza in the `/etc/network/interfaces` file:
 
 ```
 auto br0
 iface br0
     address 10.2.2.1/24
     bridge-ports glob swp1-10 swp12 glob swp14-20
+    bridge-pvid 100
     bridge-stp on
 ```
 


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Add PVID to quick start L3 interface section
Mention removal of hyperloop workaround for Trident II switches