### PR TITLE
More `ip vrf exec` replacing `vrf task exec`

### DIFF
--- a/content/cumulus-linux/Layer-3/Management-VRF.md
+++ b/content/cumulus-linux/Layer-3/Management-VRF.md
@@ -196,7 +196,7 @@ ExecStart=/usr/local/bin/ssh agent -data-dir=/tmp/ssh -bind=192.168.0.11
 ...
 ```
 
-3. Modify the *ExecStart* line to `/usr/bin/vrf exec mgmt /sbin/runuser -u USER -- ssh`:
+3. Modify the *ExecStart* line to `/usr/bin/ip vrf exec mgmt /sbin/runuser -u USER -- ssh`:
 
 ```
 ...

--- a/content/version/cumulus-linux-37/Layer-3/Management-VRF.md
+++ b/content/version/cumulus-linux-37/Layer-3/Management-VRF.md
@@ -267,10 +267,10 @@ route-map REDISTRIBUTE-CONNECTED permit 1000
 
 ## SSH within a Management VRF Context
 
-If you SSH to the switch through a switch port, SSH works as expected. If you need to SSH from the device out of a switch port, use `vrf exec default ssh <ip_address_of_swp_port>`. For example:
+If you SSH to the switch through a switch port, SSH works as expected. If you need to SSH from the device out of a switch port, use `ip vrf exec default ssh <ip_address_of_swp_port>`. For example:
 
 ```
-cumulus@switch:~$ sudo vrf exec default ssh 10.23.23.2 10.3.3.3
+cumulus@switch:~$ sudo ip vrf exec default ssh 10.23.23.2 10.3.3.3
 ```
 
 ## View the Routing Tables


### PR DESCRIPTION
Ticket: UD-1834
Reviewed By:
Testing Done:

Found a couple instances of `vrf exec` and not `vrf task exec`, so changed these to `ip vrf exec` as well.