### PR TITLE
Fix font weight for H4 H5

### DIFF
--- a/themes/netDocs/assets/_markdown.scss
+++ b/themes/netDocs/assets/_markdown.scss
@@ -43,7 +43,7 @@ $block-border-radius: 0.15rem;
   h4 {
     color: $black;
     font-size: .882rem;
-    font-weight: 500;
+    font-weight: 400;
     letter-spacing: 1.25px;
     line-height: 24px;
   }
@@ -51,7 +51,7 @@ $block-border-radius: 0.15rem;
   h5 {
     color: $black;
     font-size: .674rem;
-    font-weight: 500;
+    font-weight: 400;
     letter-spacing: 1.1px;
     line-height: 18px;
     text-transform: uppercase;


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Make font weight the same for H3 - H5.