### PR TITLE
Trident3 ACL limits

### DIFF
--- a/content/cumulus-linux/System-Configuration/Netfilter-ACLs/_index.md
+++ b/content/cumulus-linux/System-Configuration/Netfilter-ACLs/_index.md
@@ -659,14 +659,32 @@ In the tables below, the default rules count toward the limits listed. The raw l
 
 ### Broadcom Tomahawk Limits
 
-|Direction|Atomic Mode IPv4 Rules|Atomic Mode IPv6 Rules|Nonatomic Mode IPv4 Rules|Nonatomic Mode IPv6 Rules|
-|----------|---------|---------|-----------|----------|
-|Ingress raw limit|512|512|1024|1024|
-|Ingress limit with default rules|256 (36 default)| 256 (29 default)|768 (36 default)|768 (29 default)|
-|Egress raw limit |256 |0 |512| 0|
-|Egress limit with default rules|256 (29 default)|0| 512 (29 default) |0|
+| Direction                        | Atomic Mode IPv4 Rules | Atomic Mode IPv6 Rules | Nonatomic Mode IPv4 Rules | Nonatomic Mode IPv6 Rules |
+| -------------------------------- | ---------------------- | ---------------------- | ------------------------- | ------------------------- |
+| Ingress raw limit                | 512                    | 512                    | 1024                      | 1024                      |
+| Ingress limit with default rules | 256 (36 default)       | 256 (29 default)       | 768 (36 default)          | 768 (29 default)          |
+| Egress raw limit                 | 256                    | 0                      | 512                       | 0                         |
+| Egress limit with default rules  | 256 (29 default)       | 0                      | 512 (29 default)          | 0                         |
 
-### Broadcom Trident II+ and Trident3 Limits
+### Broadcom Trident3 Limits
+
+The Trident3 ASIC is divided into 12 slices, organized into 4 groups for ACLs. Each group contains 3 slices. Each group can support a maximum of 768 rules. You cannot mix IPv4 and IPv6 rules within the same group. IPv4 and MAC rules can be programmed into the same group.
+
+| Direction                        | Atomic Mode IPv4 Rules | Atomic Mode IPv6 Rules | Nonatomic Mode IPv4 Rules | Nonatomic Mode IPv6 Rules |
+| -------------------------------- | ---------------------- | ---------------------- | ------------------------- | ------------------------- |
+| Ingress raw limit                | 768                    | 768                    | 2304                      | 2304                      |
+| Ingress limit with default rules | 768 (44 default)       | 768 (41 default)       | 2304 (44 default)         | 2304 (41 default)         |
+| Egress raw limit                 | 512                    | 0                      | 512                       | 0                         |
+| Egress limit with default rules  | 512 (28 default)       | 0                      | 512 (28 default)          | 0                         |
+
+### Broadcom Trident II+ Limits
+
+| Direction                        | Atomic Mode IPv4 Rules | Atomic Mode IPv6 Rules | Nonatomic Mode IPv4 Rules | Nonatomic Mode IPv6 Rules |
+| -------------------------------- | ---------------------- | ---------------------- | ------------------------- | ------------------------- |
+| Ingress raw limit                | 4096                   | 4096                   | 8192                      | 8192                      |
+| Ingress limit with default rules | 2048 (36 default)      | 3072 (29 default)      | 6144 (36 default)         | 6144 (29 default)         |
+| Egress raw limit                 | 256                    | 0                      | 512                       | 0                         |
+| Egress limit with default rules  | 256 (29 default)       | 0                      | 512 (29 default)          | 0                         |
 
 ### Broadcom Trident II Limits
 

--- a/content/version/cumulus-linux-37/System-Configuration/Netfilter-ACLs/_index.md
+++ b/content/version/cumulus-linux-37/System-Configuration/Netfilter-ACLs/_index.md
@@ -851,7 +851,18 @@ present.
 | Egress raw limit                 | 256                    | 0                      | 512                       | 0                         |
 | Egress limit with default rules  | 256 (29 default)       | 0                      | 512 (29 default)          | 0                         |
 
-### Broadcom Trident II+ and Trident3 Limits
+### Broadcom Trident3 Limits
+
+The Trident3 ASIC is divided into 12 slices, organized into 4 groups for ACLs. Each group contains 3 slices. Each group can support a maximum of 768 rules. You cannot mix IPv4 and IPv6 rules within the same group. IPv4 and MAC rules can be programmed into the same group.
+
+| Direction                        | Atomic Mode IPv4 Rules | Atomic Mode IPv6 Rules | Nonatomic Mode IPv4 Rules | Nonatomic Mode IPv6 Rules |
+| -------------------------------- | ---------------------- | ---------------------- | ------------------------- | ------------------------- |
+| Ingress raw limit                | 768                    | 768                    | 2304                      | 2304                      |
+| Ingress limit with default rules | 768 (44 default)       | 768 (41 default)       | 2304 (44 default)         | 2304 (41 default)         |
+| Egress raw limit                 | 512                    | 0                      | 512                       | 0                         |
+| Egress limit with default rules  | 512 (28 default)       | 0                      | 512 (28 default)          | 0                         |
+
+### Broadcom Trident II+ Limits
 
 | Direction                        | Atomic Mode IPv4 Rules | Atomic Mode IPv6 Rules | Nonatomic Mode IPv4 Rules | Nonatomic Mode IPv6 Rules |
 | -------------------------------- | ---------------------- | ---------------------- | ------------------------- | ------------------------- |


### PR DESCRIPTION
Ticket: UD-1846 UD-1847
Reviewed By: rama
Testing Done:

Trident3 ACL limits were incorrect for 3.7 and the T3 and Trident II+ limits were missing altogether for 4.0.