### PR TITLE
Chassis is for 3.x only

### DIFF
--- a/themes/netDocs/layouts/home.html
+++ b/themes/netDocs/layouts/home.html
@@ -171,11 +171,10 @@
               </ul>
             </div>
             <div class="col-sm-12 col-md-6 col-lg-4">
-              <h3>Chassis</h3>
+              <h3>Chassis<br />(Cumulus Linux 3.x only)</h3>
               <ul>
                 <li><a href="/chassis/">Overview</a></li>
                 <li><a href="/chassis/Chassis-Default-Configurations/">Default configurations</a></li>
-                <li><a href="/chassis/Chassis-specific-Commands/">Chassis-specific commands</a></li>
               </ul>
             </div>
             <div class="col-sm-12 col-md-6 col-lg-4">


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Chassis supported only under Cumulus Linux 3.x.