### PR TITLE
Bump up TOC level depth

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,7 @@ enableRobotsTXT = true
 
 [markup]
   [markup.tableOfContents]
-    endLevel = 3
+    endLevel = 4
     ordered = false
     startLevel = 1
   [markup.goldmark]


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

TOC on the right hand side used to go 3 levels deep, but was changed to 2. This reverts it back to 3 levels deep.