### PR TITLE
vrf task command replacements, correct platform name

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -42,7 +42,7 @@ frontend:
         #- if [ "${AWS_BRANCH}" = "master" ]; then python3 utils/build_pdfs.py $DOCRAPTOR_KEY https://stage.docs.cumulusnetworks.com/ $USERNAME $PASSWORD ; fi
         #- echo Building docs ...
         # Don't minify in non-prod branches to simplify troubleshooting
-        - if [ "${AWS_BRANCH}" != "master" ]; then hugo --baseURL $BASEURL ; fi
+        - if [ "${AWS_BRANCH}" != "master" ]; then hugo -D --baseURL $BASEURL ; fi
         - if [ "${AWS_BRANCH}" = "master" ]; then hugo --minify --baseURL $BASEURL ; fi
         - echo Successfully built docs
         # If everything else worked, and this is master, then cut a new release.

--- a/content/cumulus-linux-37/Layer-3/Management-VRF.md
+++ b/content/cumulus-linux-37/Layer-3/Management-VRF.md
@@ -138,7 +138,7 @@ cumulus@switch:~$ sudo systemctl enable ntp@mgmt.service
 cumulus@switch:~$ ps aux | grep ntp
 ntp       7294  0.0  0.4  81320  2108 ?        Ssl  22:22   0:00 /usr/sbin/ntpd -n -u ntp:ntp -g
 cumulus   7906  0.0  0.4  12728  2056 tty1     S+   22:34   0:00 grep ntp
-cumulus@switch:~$ vrf task identify 7294
+cumulus@switch:~$ ip vrf identify 7294
 mgmt
 ```
 

--- a/content/cumulus-linux-37/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-37/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -152,9 +152,9 @@ To get a list of VRF tables, run:
     rocket            1016
 
 To return a list of processes and PIDs associated with a specific VRF
-table, run `vrf task list <vrf-name>`. For example:
+table, run `ip vrf pids <vrf-name>`. For example:
 
-    cumulus@switch:~$ vrf task list rocket
+    cumulus@switch:~$ ip vrf pids rocket
      
     VRF: rocket            
     -----------------------
@@ -166,9 +166,9 @@ table, run `vrf task list <vrf-name>`. For example:
     vrf                2829
 
 To determine which VRF table is associated with a particular PID, run
-`vrf task identify <pid>`. For example:
+`ip vrf identify <pid>`. For example:
 
-    cumulus@switch:~$ vrf task identify 2829
+    cumulus@switch:~$ ip vrf identify 2829
      
     rocket
 

--- a/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/Network-Switch-Port-LED-and-Status-LED-Guidelines.md
+++ b/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/Network-Switch-Port-LED-and-Status-LED-Guidelines.md
@@ -78,10 +78,9 @@ A set of status LEDs are typically located on one side of a network switch. The 
 
 Cumulus Linux supports the locator LED functionality for identifying a switch, by blinking a single LED on a specified network port, on the following switches:
 
-- Celestica Seastone
 - Dell Z9100-ON
 - Edgecore AS7712-32X
-- Penguin Arctica 3200C
+- Penguin Arctica 3200c
 - Quanta QuantaMesh BMS T4048-IX2
 - Supermicro SSE-C3632S
 
@@ -115,6 +114,6 @@ If you set the ports to 100M, the link lights for ports 1-46 are orange, while t
 
 When all of the ports are set to 1G, all the link lights are green.
 
-### Celestica SeaStone2 Front Panel ALARM LED
+### Penguin Arctica 3200c Front Panel ALARM LED
 
-On the Celestica SeaStone2 switch, the front panel ALARM LED is not functional and remains off when you remove or insert a power module. The rear panel ALARM always flashes yellow.
+On the Penguin Arctica 3200c switch, the front panel ALARM LED is not functional and remains off when you remove or insert a power module. The rear panel ALARM always flashes yellow.

--- a/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/_index.md
+++ b/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/_index.md
@@ -122,7 +122,7 @@ and voltage information:
     PSU2:  OK
     power:8.5 W   (voltages = ['11.98', '11.87'] V currents = ['0.72'] A)
 
-Whereas the Penguin Arctica 3200C (Celestica Seastone) does not:
+Whereas the Penguin Arctica 3200c does not:
 
     cumulus@cel-sea:~/tmp$ sudo smonctl -v -s PSU1
     PSU1:  OK

--- a/content/cumulus-linux-40/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-40/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -159,10 +159,10 @@ VRF              Table
 rocket            1016
 ```
 
-To show a list of processes and PIDs associated with a specific VRF table, run the `vrf task list <vrf-name>` command. For example:
+To show a list of processes and PIDs associated with a specific VRF table, run the `ip vrf pids <vrf-name>` command. For example:
 
 ```
-cumulus@switch:~$ vrf task list rocket
+cumulus@switch:~$ ip vrf pids rocket
 
 VRF: rocket
 -----------------------
@@ -175,10 +175,10 @@ vrf                2829
 ```
 
 To determine which VRF table is associated with a particular PID, run
-the `vrf task identify <pid>` command. For example:
+the `ip vrf identify <pid>` command. For example:
 
 ```
-cumulus@switch:~$ vrf task identify 2829
+cumulus@switch:~$ ip vrf identify 2829
 rocket
 ```
 

--- a/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/Network-Switch-Port-LED-and-Status-LED-Guidelines.md
+++ b/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/Network-Switch-Port-LED-and-Status-LED-Guidelines.md
@@ -78,10 +78,9 @@ A set of status LEDs are typically located on one side of a network switch. The 
 
 Cumulus Linux supports the locator LED functionality for identifying a switch, by blinking a single LED on a specified network port, on the following switches:
 
-- Celestica Seastone
 - Dell Z9100-ON
 - Edgecore AS7712-32X
-- Penguin Arctica 3200C
+- Penguin Arctica 3200c
 - Quanta QuantaMesh BMS T4048-IX2
 - Supermicro SSE-C3632S
 
@@ -119,6 +118,6 @@ When all of the ports are set to 1G, all the link lights are green.
 
 The port LED blink state that indicates link activity is not implemented; the ports only have ON/OFF states.
 
-### Celestica SeaStone2 Front Panel ALARM LED
+### Penguin Arctica 3200c Front Panel ALARM LED
 
-On the Celestica SeaStone2 switch, the front panel ALARM LED is not functional and remains off when you remove or insert a power module. The rear panel ALARM always flashes yellow.
+On the Penguin Arctica 3200c switch, the front panel ALARM LED is not functional and remains off when you remove or insert a power module. The rear panel ALARM always flashes yellow.

--- a/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/_index.md
+++ b/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/_index.md
@@ -113,7 +113,7 @@ PSU2:  OK
 power:8.5 W   (voltages = ['11.98', '11.87'] V currents = ['0.72'] A)
 ```
 
-The Penguin Arctica 3200C (Celestica Seastone) does not have this sensor:
+The Penguin Arctica 3200c does not have this sensor:
 
 ```
 cumulus@cel-sea:~/tmp$ sudo smonctl -v -s PSU1

--- a/content/cumulus-linux-41/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
+++ b/content/cumulus-linux-41/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
@@ -1601,10 +1601,8 @@ The Lenovo NE2572O switch has external retimers on swp1 through swp8. Currently,
 
 The following switches that use Serial over LAN technology (SOL) do not support eth0 speed or auto-negotiation changes:
 
-- Celestica Pebble
-- Celestica QueStone2
-- Celestica SeaStone2
 - EdgeCore AS7816-64X
+- Penguin Arctica 4804ip
 - Penguin Arctica NX3200c
 - Penguin Arctica NX4808xxv
 

--- a/content/cumulus-linux-41/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-41/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -159,10 +159,10 @@ VRF              Table
 rocket            1016
 ```
 
-To show a list of processes and PIDs associated with a specific VRF table, run the `vrf task list <vrf-name>` command. For example:
+To show a list of processes and PIDs associated with a specific VRF table, run the `ip vrf pids <vrf-name>` command. For example:
 
 ```
-cumulus@switch:~$ vrf task list rocket
+cumulus@switch:~$ ip vrf pids rocket
 
 VRF: rocket
 -----------------------
@@ -175,10 +175,10 @@ vrf                2829
 ```
 
 To determine which VRF table is associated with a particular PID, run
-the `vrf task identify <pid>` command. For example:
+the `ip vrf identify <pid>` command. For example:
 
 ```
-cumulus@switch:~$ vrf task identify 2829
+cumulus@switch:~$ ip vrf identify 2829
 rocket
 ```
 

--- a/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/Network-Switch-Port-LED-and-Status-LED-Guidelines.md
+++ b/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/Network-Switch-Port-LED-and-Status-LED-Guidelines.md
@@ -78,10 +78,9 @@ A set of status LEDs are typically located on one side of a network switch. The 
 
 Cumulus Linux supports the locator LED functionality for identifying a switch, by blinking a single LED on a specified network port, on the following switches:
 
-- Celestica Seastone
 - Dell Z9100-ON
 - Edgecore AS7712-32X
-- Penguin Arctica 3200C
+- Penguin Arctica 3200c
 - Quanta QuantaMesh BMS T4048-IX2
 - Supermicro SSE-C3632S
 
@@ -119,6 +118,6 @@ When all of the ports are set to 1G, all the link lights are green.
 
 The port LED blink state that indicates link activity is not implemented; the ports only have ON/OFF states.
 
-### Celestica SeaStone2 Front Panel ALARM LED
+### Penguin Arctica 3200c Front Panel ALARM LED
 
-On the Celestica SeaStone2 switch, the front panel ALARM LED is not functional and remains off when you remove or insert a power module. The rear panel ALARM always flashes yellow.
+On the Penguin Arctica 3200c switch, the front panel ALARM LED is not functional and remains off when you remove or insert a power module. The rear panel ALARM always flashes yellow.

--- a/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/_index.md
+++ b/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Monitoring-System-Hardware/_index.md
@@ -113,7 +113,7 @@ PSU2:  OK
 power:8.5 W   (voltages = ['11.98', '11.87'] V currents = ['0.72'] A)
 ```
 
-The Penguin Arctica 3200C (Celestica Seastone) does not have this sensor:
+The Penguin Arctica 3200c does not have this sensor:
 
 ```
 cumulus@cel-sea:~/tmp$ sudo smonctl -v -s PSU1


### PR DESCRIPTION
Replace vrf task commands with ip counterparts 
Replace Seastone2 with Arctica 3200c 