### PR TITLE
mz link updates

### DIFF
--- a/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Network-Troubleshooting/_index.md
+++ b/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Network-Troubleshooting/_index.md
@@ -152,8 +152,7 @@ you can disable dynamic ARP learning:
 
 ## Generate Traffic Using mz
 
-`mz` is a fast traffic generator. It can generate a large variety of
-packet types at high speed. See `man mz` for details.
+`{{<exlink url="http://www.netsniff-ng.org" text="mz">}}` (or `mausezahn`) is a fast traffic generator. It can generate a large variety of packet types at high speed. See `man mz` for details.
 
 For example, to send two sets of packets to TCP port 23 and 24, with
 source IP 11.0.0.1 and destination 11.0.0.2, do the following:

--- a/content/cumulus-linux-37/System-Configuration/Netfilter-ACLs/_index.md
+++ b/content/cumulus-linux-37/System-Configuration/Netfilter-ACLs/_index.md
@@ -1291,12 +1291,7 @@ of packets.
 
 ### Check the Packet and Byte Counters for ACL Rules
 
-To verify the counters using the above example rules, first send test
-traffic matching the patterns through the network. The following example
-generates traffic with [mz](http://www.perihel.at/sec/mz/), which can be
-installed on host servers or even on Cumulus Linux switches. After
-traffic is sent to validate the counters, they are matched on switch1
-use `cl-acltool`.
+To verify the counters using the above example rules, first send test traffic matching the patterns through the network. The following example generates traffic with `{{<exlink url="http://www.netsniff-ng.org" text="mz">}}` (or `mausezahn`), which can be installed on host servers or even on Cumulus Linux switches. After traffic is sent to validate the counters, they are matched on switch1 use `cl-acltool`.
 
 {{%notice note%}}
 

--- a/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Network-Troubleshooting/_index.md
+++ b/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Network-Troubleshooting/_index.md
@@ -140,7 +140,7 @@ cumulus@switch:~$ ip link set arp off dev INTERFACE
 
 ## Generate Traffic Using mz
 
-`mz` is a fast traffic generator. It can generate a large variety of packet types at high speed. See `man mz` for details.
+`{{<exlink url="http://www.netsniff-ng.org" text="mz">}}` (or `mausezahn`) is a fast traffic generator. It can generate a large variety of packet types at high speed. See `man mz` for details.
 
 For example, to send two sets of packets to TCP port 23 and 24, with source IP address 11.0.0.1 and destination IP address 11.0.0.2:
 

--- a/content/cumulus-linux-40/System-Configuration/Netfilter-ACLs/_index.md
+++ b/content/cumulus-linux-40/System-Configuration/Netfilter-ACLs/_index.md
@@ -957,7 +957,7 @@ The examples here use the DSCP match criteria in combination with other IP, TCP,
 
 ### Check the Packet and Byte Counters for ACL Rules
 
-To verify the counters using the above example rules, first send test traffic matching the patterns through the network. The following example generates traffic with `{{<exlink url="https://en.wikipedia.org/wiki/Mausezahn" text="mz">}}` (mausezahn), which can be installed on host servers or even on Cumulus Linux switches. After traffic is sent to validate the counters, they are matched on switch1 using `cl-acltool`.
+To verify the counters using the above example rules, first send test traffic matching the patterns through the network. The following example generates traffic with `{{<exlink url="http://www.netsniff-ng.org" text="mz">}}` (or `mausezahn`), which can be installed on host servers or even on Cumulus Linux switches. After traffic is sent to validate the counters, they are matched on switch1 using `cl-acltool`.
 
 {{%notice note%}}
 

--- a/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Network-Troubleshooting/_index.md
+++ b/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Network-Troubleshooting/_index.md
@@ -140,7 +140,7 @@ cumulus@switch:~$ ip link set arp off dev INTERFACE
 
 ## Generate Traffic Using mz
 
-`mz` is a fast traffic generator. It can generate a large variety of packet types at high speed. See `man mz` for details.
+`{{<exlink url="http://www.netsniff-ng.org" text="mz">}}` (or `mausezahn`) is a fast traffic generator. It can generate a large variety of packet types at high speed. See `man mz` for details.
 
 For example, to send two sets of packets to TCP port 23 and 24, with source IP address 11.0.0.1 and destination IP address 11.0.0.2:
 

--- a/content/cumulus-linux-41/System-Configuration/Netfilter-ACLs/_index.md
+++ b/content/cumulus-linux-41/System-Configuration/Netfilter-ACLs/_index.md
@@ -959,7 +959,7 @@ The examples here use the DSCP match criteria in combination with other IP, TCP,
 
 ### Check the Packet and Byte Counters for ACL Rules
 
-To verify the counters using the above example rules, first send test traffic matching the patterns through the network. The following example generates traffic with `{{<exlink url="https://en.wikipedia.org/wiki/Mausezahn" text="mz">}}` (mausezahn), which can be installed on host servers or even on Cumulus Linux switches. After traffic is sent to validate the counters, they are matched on switch1 using `cl-acltool`.
+To verify the counters using the above example rules, first send test traffic matching the patterns through the network. The following example generates traffic with `{{<exlink url="http://www.netsniff-ng.org" text="mz">}}` (or `mausezahn`), which can be installed on host servers or even on Cumulus Linux switches. After traffic is sent to validate the counters, they are matched on switch1 using `cl-acltool`.
 
 {{%notice note%}}
 


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

The mz/mausezahn project was taken over by netsniff-ng.org. Updating links to their site since the original site was taken down.