### PR TITLE
Replace dynamic link with static link in old version warning

### DIFF
--- a/themes/netDocs/layouts/_default/list.html
+++ b/themes/netDocs/layouts/_default/list.html
@@ -10,9 +10,7 @@
   <p>This documentation is for an older version of the software. If you are
   using the current version of Cumulus Linux, this content may not be up
   to date. The current version of the documentation is available
-  {{ $prod := (index (where .Site.Sections "Params.product" .Page.Params.product) 0).Section }}
-<a href = {{ (index (where (where .Site.Pages "Section" $prod) "Title" .Page.Title) 0).RelPermalink  | default (index (where .Site.Sections "Params.product" .Page.Params.product) 0).RelPermalink }}
->here</a>. If you are redirected to the main page of the user guide, then this page may have been renamed; please search for it there.</p>
+  <a href="https://docs.cumulusnetworks.com/cumulus-linux/">here</a>. If you are redirected to the main page of the user guide, then this page may have been renamed; please search for it there.</p>
 </div>
 {{ end }}
 <article class="markdown">

--- a/themes/netDocs/layouts/_default/single.html
+++ b/themes/netDocs/layouts/_default/single.html
@@ -11,9 +11,7 @@
   <p>This documentation is for an older version of the software. If you are
   using the current version of Cumulus Linux, this content may not be up
   to date. The current version of the documentation is available
-  {{ $prod := (index (where .Site.Sections "Params.product" .Page.Params.product) 0).Section }}
-<a href = {{ (index (where (where .Site.Pages "Section" $prod) "Title" .Page.Title) 0).RelPermalink  | default (index (where .Site.Sections "Params.product" .Page.Params.product) 0).RelPermalink }}
->here</a>. If you are redirected to the main page of the user guide, then this page may have been renamed; please search for it there.</p>
+<a href="https://docs.cumulusnetworks.com/cumulus-linux/">here</a>. If you are redirected to the main page of the user guide, then this page may have been renamed; please search for it there.</p>
 </div>
 {{ end }} 
 <article class="markdown">


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Dynamic link in the old version warning was pointing to version 4.0, not the current version. This is a temporary fix to redirect to the main page of the current doc version.