### PR TITLE
Minimum CL version for `config agent cpu-limit` command

### DIFF
--- a/content/cumulus-netq-24/Cumulus-NetQ-CLI-User-Guide/Command-Changes.md
+++ b/content/cumulus-netq-24/Cumulus-NetQ-CLI-User-Guide/Command-Changes.md
@@ -33,7 +33,7 @@ The following table summarizes the new commands available with this release. The
 </tr>
 <tr>
   <td>netq config add agent cpu-limit [&lt;text-limit-number>]</td>
-  <td>Limits the amount of CPU resources the NetQ Agent consumes on a Cumulus Linux switch.</td>
+  <td>Limits the amount of CPU resources the NetQ Agent consumes on a Cumulus Linux switch. This setting requires Cumulus Linux versions 3.7.12 or later and 4.1.0 or later to be running on the switch.</td>
   <td>2.4.1</td>
 </tr>
 <tr>

--- a/content/cumulus-netq-24/Cumulus-NetQ-CLI-User-Guide/Manage-NetQ-Agents.md
+++ b/content/cumulus-netq-24/Cumulus-NetQ-CLI-User-Guide/Manage-NetQ-Agents.md
@@ -105,7 +105,8 @@ You can optionally specify a port or VRF.
     cumulus@switch:~$ netq config add agent cluster-servers 10.0.0.21,10.0.0.22,10.0.0.23 vrf rocket
 
 This example shows how to prevent the agent from consuming no more than 40% of
-CPU resources on a Cumulus Linux switch.
+CPU resources on a Cumulus Linux switch. This setting requires Cumulus Linux
+versions 3.7.12 or later and 4.1.0 or later to be running on the switch.
 
     netq config add agent cpu-limit 40
 

--- a/content/cumulus-netq-30/Cumulus-NetQ-CLI-User-Guide/Manage-NetQ-Agents.md
+++ b/content/cumulus-netq-30/Cumulus-NetQ-CLI-User-Guide/Manage-NetQ-Agents.md
@@ -105,7 +105,8 @@ You can optionally specify a port or VRF.
     cumulus@switch:~$ netq config add agent cluster-servers 10.0.0.21,10.0.0.22,10.0.0.23 vrf rocket
 
 This example shows how to prevent the agent from consuming no more than 40% of
-CPU resources on a Cumulus Linux switch.
+CPU resources on a Cumulus Linux switch. This setting requires Cumulus Linux
+versions 3.7.12 or later and 4.1.0 or later to be running on the switch.
 
     netq config add agent cpu-limit 40
 


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

In order to use the `netq config add agent cpu-limit` command, the target switch must be running Cumulus Linux 3.7.12 or 4.1.0 or later.