### PR TITLE
Preformatted CSS, release note page weight

### DIFF
--- a/themes/netDocs/assets/custom.scss
+++ b/themes/netDocs/assets/custom.scss
@@ -1555,6 +1555,11 @@ footer {
 }
 
 .markdown pre {
+  //white-space: pre-wrap; 
+  overflow-x: auto;
+}
+
+.markdown td pre {
   white-space: pre-wrap; 
   overflow-x: auto;
 }

--- a/utils/build_rns.py
+++ b/utils/build_rns.py
@@ -211,7 +211,7 @@ def build_markdown_header(product, version):
     output.append("---\n")
     output.append("title: {} {} Release Notes\n".format(product, version))
     output.append("author: Cumulus Networks\n")
-    output.append("weight: -30\n")
+    output.append("weight: -20\n")
     output.append("product: {}\n".format(product))
     output.append("version: \"{}\"\n".format(version))
     output.append("toc: 1\n")


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Add CSS for PRE tags in table cells so they don't scroll, but PRE tags outside of tables do scroll.
Change weight for release notes page so it is ordered before the FOSS license page (when it returns).