### PR TITLE
Remove suggestion to use only a single link

### DIFF
--- a/content/cumulus-linux-37/Layer-3/Redistribute-Neighbor.md
+++ b/content/cumulus-linux-37/Layer-3/Redistribute-Neighbor.md
@@ -30,7 +30,6 @@ Redistribute neighbor was created with these use cases in mind:
 
 Cumulus Networks recommends following these guidelines with redistribute neighbor:
 
-- Use a single logical connection from each host to each leaf.
 - A host can connect to one or more leafs. Each leaf advertises the /32 it sees in its neighbor table.
 - A host-bound bridge/VLAN should be local to each switch only.
 - Leaf switches with redistribute neighbor enabled should be directly connected to the hosts.

--- a/content/cumulus-linux-40/Layer-3/Redistribute-Neighbor.md
+++ b/content/cumulus-linux-40/Layer-3/Redistribute-Neighbor.md
@@ -38,7 +38,6 @@ Redistribute neighbor is typically used in these configurations:
 
 Cumulus Networks recommends that you follow these guidelines:
 
-- Use a single logical connection from each host to each leaf.
 - You can connect a host to one or more leafs. Each leaf advertises the /32 it sees in its neighbor table.
 - Make sure that a host-bound bridge/VLAN is local to each switch.
 - Connect leaf switches with redistribute neighbor enabled directly to the hosts.

--- a/content/cumulus-linux-41/Layer-3/Redistribute-Neighbor.md
+++ b/content/cumulus-linux-41/Layer-3/Redistribute-Neighbor.md
@@ -38,7 +38,6 @@ Redistribute neighbor is typically used in these configurations:
 
 Cumulus Networks recommends that you follow these guidelines:
 
-- Use a single logical connection from each host to each leaf.
 - You can connect a host to one or more leafs. Each leaf advertises the /32 it sees in its neighbor table.
 - Make sure that a host-bound bridge/VLAN is local to each switch.
 - Connect leaf switches with redistribute neighbor enabled directly to the hosts.


### PR DESCRIPTION
Ticket: UD-1999
Reviewed By:
Testing Done:

Redistribute neighbor isn't restricted to a single logical connection between the host and leaf.