### PR TITLE
Mention support for EAP-TTLS for 802.1X

### DIFF
--- a/content/cumulus-linux-37/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
+++ b/content/cumulus-linux-37/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
@@ -31,71 +31,46 @@ which has been modified to provide the PAE (port access entity).
 
 ## Supported Features and Limitations
 
-  - 802.1X is supported on Broadcom-based switches (except the
-    Hurricane2 switch). The Tomahawk, Tomahawk2, and Trident3 switch
-    *must* be running in {{<link url="Netfilter-ACLs#nonatomic-update-mode-and-update-mode" text="nonatomic mode">}}.
-  - The protocol is supported on physical interfaces only
-    (bridged/access only and routed interfaces) - such as swp1 or
-    swp2s0; these interfaces cannot be part of a bond. However, 802.1X
-    is **not** supported on eth0.
-  - Cumulus Linux 3.7.2 and later includes VRF support
-  - You can configure 802.1X interfaces for bridges in both {{<link url="VLAN-aware-Bridge-Mode" text="VLAN-aware mode">}}
-    and {{<link url="Traditional-Bridge-Mode" text="traditional mode">}}
-    using the following features:
+- 802.1X is supported on Broadcom-based switches (except the Hurricane2 switch). The Tomahawk, Tomahawk2, and Trident3 switch *must* be running in {{<link url="Netfilter-ACLs#nonatomic-update-mode-and-update-mode" text="nonatomic mode">}}.
+- The protocol is supported on physical interfaces only (bridged/access only and routed interfaces) - such as swp1 or swp2s0; these interfaces cannot be part of a bond. However, 802.1X is **not** supported on eth0.
+- Cumulus Linux 3.7.2 and later includes VRF support
+- You can configure 802.1X interfaces for bridges in both {{<link url="VLAN-aware-Bridge-Mode" text="VLAN-aware mode">}} and {{<link url="Traditional-Bridge-Mode" text="traditional mode">}} using the following features:
 
-      - Parking VLAN
-      - Dynamic VLAN
-      - MAB (MAC-based authentication bypass)
+  - Parking VLAN
+  - Dynamic VLAN
+  - MAB (MAC-based authentication bypass)
 
-  - MAB, parking VLAN and dynamic VLAN all require a bridge access port.
-  - In traditional bridge mode, parking VLANs and dynamic VLANs both
-    require the destination bridge to have a parking VLAN ID or dynamic
-    VLAN ID tagged subinterface, respectively.
-  - Enabling or disabling the 802.1X capability on ports results in
-    `hostapd` reloading. However, existing authorized sessions do not
-    get reset.
-  - Changing any of the following RADIUS parameters restarts `hostapd`,
-    which forces existing, authorized users to re-authenticate:
+- MAB, parking VLAN and dynamic VLAN all require a bridge access port.
+- In traditional bridge mode, parking VLANs and dynamic VLANs both require the destination bridge to have a parking VLAN ID or dynamic VLAN ID tagged subinterface, respectively.
+- Enabling or disabling the 802.1X capability on ports results in `hostapd` reloading. However, existing authorized sessions do not get reset.
+- Changing any of the following RADIUS parameters restarts `hostapd`, which forces existing, authorized users to re-authenticate:
 
-      - The RADIUS server IP address, shared secret, authentication port
-        or accounting port
-      - Parking VLAN ID
-      - MAB activation delay
-      - EAP reauthentication period
-      - Removing all 802.1X interfaces
+  - The RADIUS server IP address, shared secret, authentication port or accounting port
+  - Parking VLAN ID
+  - MAB activation delay
+  - EAP reauthentication period
+  - Removing all 802.1X interfaces
 
-        {{%notice note%}}
+  {{%notice note%}}
 
 Changing the `interface dot1x`, `dot1x mab`, or `dot1x parking-vlan` settings do not reset existing authorized user ports.
 
-        {{%/notice%}}
+  {{%/notice%}}
 
-  - You can configure up to three RADIUS servers for failover purposes.
-  - Cumulus Networks performed tests with only a few `wpa_supplicant`
-    (Debian), Windows 10 and Windows 7 supplicants.
-  - RADIUS authentication is supported with FreeRADIUS and Cisco ACS.
-  - Supports simple login/password, PEAP/MSCHAPv2 (Win7) and EAP-TLS
-    (Debian).
-  - There is no support for Mako template-based configurations.
-  - Cumulus Linux 3.7.4 and later includes support for Multi Domain
-    Authentication (MDA), where 802.1X is extended to allow
-    authorization of multiple devices (a data and a voice device) on a
-    single port and assign different VLANs to the devices based on
-    authorization:
+- You can configure up to three RADIUS servers for failover purposes.
+- Cumulus Networks performed tests with only a few `wpa_supplicant` (Debian), Windows 10 and Windows 7 supplicants.
+- RADIUS authentication is supported with FreeRADIUS and Cisco ACS.
+- Supports simple login/password, PEAP/MSCHAPv2 (Win7) and EAP-TLS (Debian).
+- 802.1X supports {{<exlink url="https://tools.ietf.org/html/rfc5281" text="RFC 5281">}} for EAP-TTLS, which provides more secure transport layer security.
+- There is no support for Mako template-based configurations.
+- Cumulus Linux 3.7.4 and later includes support for Multi Domain Authentication (MDA), where 802.1X is extended to allow authorization of multiple devices (a data and a voice device) on a single port and assign different VLANs to the devices based on authorization:
 
-      - MDA is enabled by default; however, you need to assign a tagged
-        VLAN for voice devices see {{<link url="#configure-8021x-interfaces-for-a-vlan-aware-bridge" text="Configure 802.1X Interfaces for a VLAN-aware Bridge">}}).
-      - A maximum of four authorized devices (MAB + EAPOL) per port are
-        supported.
-      - The 802.1X enabled port must be a trunk port to allow tagged
-        voice traffic from a phone; you cannot enable 802.1X on an
-        access port.
-      - Only one untagged VLAN and one tagged VLAN is supported on the
-        802.1X enabled ports
-      - Multiple MAB (non voice) devices on a port are supported for
-        VLAN-aware bridges only. Authorization of multiple MAB devices
-        for different VLANs is not supported.
-      - The MAB timer is not required (see {{<link url="#configure-mac-authentication-bypass" text="Configure MAC Authentication Bypass">}}).
+  - MDA is enabled by default; however, you need to assign a tagged VLAN for voice devices see {{<link url="#configure-8021x-interfaces-for-a-vlan-aware-bridge" text="Configure 802.1X Interfaces for a VLAN-aware Bridge">}}).
+  - A maximum of four authorized devices (MAB + EAPOL) per port are supported.
+  - The 802.1X enabled port must be a trunk port to allow tagged voice traffic from a phone; you cannot enable 802.1X on an access port.
+  - Only one untagged VLAN and one tagged VLAN is supported on the 802.1X enabled ports
+  - Multiple MAB (non voice) devices on a port are supported for VLAN-aware bridges only. Authorization of multiple MAB devices for different VLANs is not supported.
+  - The MAB timer is not required (see {{<link url="#configure-mac-authentication-bypass" text="Configure MAC Authentication Bypass">}}).
 
 ## Install the 802.1X Package
 

--- a/content/cumulus-linux-41/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
+++ b/content/cumulus-linux-41/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
@@ -38,6 +38,7 @@ Cumulus Linux implements 802.1X through the Debian `hostapd` package, which has 
 - 802.1X on Cumulus Linux has been tested with only a few `wpa_supplicant` (Debian), Windows 10 and Windows 7 supplicants.
 - RADIUS authentication is supported with FreeRADIUS and Cisco ACS.
 - 802.1X supports simple login and password, PEAP/MSCHAPv2 (Win7) and EAP-TLS (Debian).
+- 802.1X supports {{<exlink url="https://tools.ietf.org/html/rfc5281" text="RFC 5281">}} for EAP-TTLS, which provides more secure transport layer security.
 - Mako template-based configurations are not supported.
 - Cumulus Linux supports Multi Domain Authentication (MDA), where 802.1X is extended to allow authorization of multiple devices (a data and a voice device) on a single port and assign different VLANs to the devices based on authorization.
   - MDA is enabled by default; however, you need to assign a tagged VLAN for voice devices (see {{<link text="Configure 802.1X Interfaces for a VLAN-aware Bridge" title="#configure-8021x-interfaces-for-a-vlan-aware-bridge">}}).


### PR DESCRIPTION
Ticket: UD-2011
Reviewed By:
Testing Done:

Cumulus Linux 3.7.12 and 4.1 both support EAP-TTLS (RFC 5281) for 802.1X interfaces.