### PR TITLE
Expand shortcode tweaks + CSS

### DIFF
--- a/themes/netDocs/assets/custom.scss
+++ b/themes/netDocs/assets/custom.scss
@@ -1569,3 +1569,16 @@ footer {
   position: fixed;
   width: 0;
 }
+
+.expand {
+  border-radius: $border-radius;
+  border: $padding-1 solid $cn-heather;
+}
+
+.expand-label {
+  color: $cn-jade;
+}
+
+.expand-content {
+  padding: $padding-16;
+}

--- a/themes/netDocs/layouts/shortcodes/expand.html
+++ b/themes/netDocs/layouts/shortcodes/expand.html
@@ -1,7 +1,7 @@
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
         <i style="font-size:x-small;" class="fas fa-chevron-right"></i>
-      <span>
+      <span> <strong>&#9660;</strong>
         {{$expandMessage := T "Expand-title"}}
     	{{ if .IsNamedParams }}
     	{{.Get "default" | default $expandMessage}}
@@ -11,6 +11,6 @@
     	</span>
     </div>
     <div class="expand-content" style="display: none;">
-        {{.Inner | safeHTML}}
+        {{.Inner | markdownify}}
     </div>
 </div>


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Expand shortcode needed to use markdownify not safeHTML.
Added some CSS for the expanded content.