### PR TITLE
`netq bootstrap worker` fix, search box on home page

### DIFF
--- a/content/cumulus-netq-24/Cumulus-NetQ-Deployment-Guide/Install-NetQ/Install-NetQ-Platform/NetQ-Appliance-Setup-clstr-op.md
+++ b/content/cumulus-netq-24/Cumulus-NetQ-Deployment-Guide/Install-NetQ/Install-NetQ-Platform/NetQ-Appliance-Setup-clstr-op.md
@@ -142,7 +142,7 @@ Make a note of the private IP addresses you assign to the master and worker node
 12. Run the Bootstrap CLI on the appliance *for the interface you defined above* (eth0 or eth1 for example). This example uses the *eth0* interface.
 
     ```
-    cumulus@<hostname>:~$ netq bootstrap worker interface eth0 tarball /mnt/installables/netq-bootstrap-2.4.1.tgz
+    cumulus@<hostname>:~$ netq bootstrap worker tarball /mnt/installables/netq-bootstrap-2.4.1.tgz master-ip 192.168.1.222
     ```
 
     Allow about five minutes for this to complete,  and only then continue to the next step.

--- a/content/cumulus-netq-30/Cumulus-NetQ-UI-User-Guide/Monitor-Network-Performance/Monitor-Network-Health.md
+++ b/content/cumulus-netq-30/Cumulus-NetQ-UI-User-Guide/Monitor-Network-Performance/Monitor-Network-Health.md
@@ -104,7 +104,7 @@ trend of the:
 <td>Percentage of devices which passed validation versus the number of devices checked during the time window for:
 <ul>
 <li><strong>System health</strong>: NetQ Agent health, Cumulus Linux license status, and sensors</li>
-<li><strong>Network services health</strong>: BGP, CLAG, EVPN, LNV, NTP, OSPF, and VXLAN health</li>
+<li><strong>Network services health</strong>: BGP, CLAG, EVPN, NTP, OSPF, and VXLAN health</li>
 <li><strong>Interface health</strong>: interfaces MTU, VLAN health</li>
 </ul>
 <p>The data collection window varies based on the time period of the card. For a 24 hour time period (default), the window is one hour. This gives you current, hourly, updates about your network health.</p></td>
@@ -202,7 +202,7 @@ The *Network Service Health* tab displays:
 </tr>
 <tr class="odd">
 <td>Health trend</td>
-<td>Trend of BGP, CLAG, EVPN, LNV, NTP, OSPF, and VXLAN services health, represented by an arrow:
+<td>Trend of BGP, CLAG, EVPN, NTP, OSPF, and VXLAN services health, represented by an arrow:
 <ul>
 <li><strong>Pointing upward and green</strong>: Health score in the most recent window is higher than in the last two data collection windows, an increasing trend</li>
 <li><strong>Pointing downward and bright pink</strong>: Health score in the most recent window is lower than in the last two data collection windows, a decreasing trend</li>
@@ -212,12 +212,12 @@ The *Network Service Health* tab displays:
 </tr>
 <tr class="even">
 <td>Health score</td>
-<td><p>Percentage of devices which passed validation versus the number of devices checked during the time window for BGP, CLAG, EVPN, LNV, NTP, and VXLAN protocols and services.</p>
+<td><p>Percentage of devices which passed validation versus the number of devices checked during the time window for BGP, CLAG, EVPN, NTP, and VXLAN protocols and services.</p>
 <p>The data collection window varies based on the time period of the card. For a 24 hour time period (default), the window is one hour. This gives you current, hourly, updates about your network health.</p></td>
 </tr>
 <tr class="odd">
 <td>Charts</td>
-<td>Distribution of passing validations for BGP, CLAG, EVPN, LNV, NTP, and VXLAN services during the designated time period</td>
+<td>Distribution of passing validations for BGP, CLAG, EVPN, NTP, and VXLAN services during the designated time period</td>
 </tr>
 <tr class="even">
 <td>Table</td>
@@ -438,7 +438,7 @@ From the System Health tab on the large Network Health card you can click on a c
 
 ## View Network Services Health
 
-The network services health is a calculated average of the individual network protocol and services health metrics. In all cases, validation is performed on NTP. If you are running BGP, CLAG, EVPN, LNV, OSPF, or VXLAN protocols the calculation includes these as well. You can view the overall health of network services from the medium Network Health card and information about individual services from the Network Service Health tab on the large Network Health card.
+The network services health is a calculated average of the individual network protocol and services health metrics. In all cases, validation is performed on NTP. If you are running BGP, CLAG, EVPN, OSPF, or VXLAN protocols the calculation includes these as well. You can view the overall health of network services from the medium Network Health card and information about individual services from the Network Service Health tab on the large Network Health card.
 
 To view information about each network protocol or service:
 

--- a/themes/netDocs/assets/custom.scss
+++ b/themes/netDocs/assets/custom.scss
@@ -1546,8 +1546,19 @@ footer {
 
 #gsc-i-id1 {
   background: unset !important;
+  height: 40px !important;
   text-indent: unset !important;
 }
+
+.gsc-search-button-v2 {
+  height: 50px !important;
+}
+
+.gsc-search-button-v2 svg {
+  height: 25px;
+  width: 25px;
+}
+
 
 .search-hint {
   margin-top: 20px;

--- a/themes/netDocs/layouts/home.html
+++ b/themes/netDocs/layouts/home.html
@@ -70,7 +70,23 @@
         <div class="row">
           <div class="col-12 text-center">
             <h3 class="header-fancy">
-              <span>Get Started</span>
+              <span>Search the Docs</span>
+            </h3>
+          </div>
+          <div class="col-12 text-center pb-5">
+          <!--  <div class="resources-search"> -->
+          <!-- <input type="text" class="resources-search-input" placeholder="Search the documentation" value="">
+          <button type="submit">Search</button> -->
+  
+          <script async src="https://cse.google.com/cse.js?cx=002929300794741444210:sy0sz3qlwdc"></script>
+          <div class="gcse-searchbox-only" enableAutoComplete="true" data-resultsUrl="/search/"></div>
+          <!-- </div> -->
+        </div>
+      </div>
+        <div class="row">
+          <div class="col-12 text-center">
+            <h3 class="header-fancy">
+              <span>Read the Docs</span>
             </h3>
           </div>
           <div class="col-12 col-sm-6 col-lg-4 mb-5 mb-lg-0">
@@ -122,21 +138,6 @@
     <section class="bg-athens-gray-white pb-5">
         <div class="container">
           <div class="row">
-            <div class="col-12 text-center">
-              <h3 class="header-fancy">
-                <span>Search the Docs</span>
-              </h3>
-            </div>
-            <div class="col-12 text-center pb-5">
-            <!--  <div class="resources-search"> -->
-            <!-- <input type="text" class="resources-search-input" placeholder="Search the documentation" value="">
-            <button type="submit">Search</button> -->
-    
-            <script async src="https://cse.google.com/cse.js?cx=002929300794741444210:sy0sz3qlwdc"></script>
-            <div class="gcse-searchbox-only" enableAutoComplete="true" data-resultsUrl="/search/"></div>
-            <!-- </div> -->
-          </div>
-        </div><div class="row">
           <div class="col-12 text-center">
             <h3 class="header-fancy">
               <span>Additional Resources</span>

--- a/themes/netDocs/layouts/home.html
+++ b/themes/netDocs/layouts/home.html
@@ -119,9 +119,24 @@
         </div>
       </div>
     </section>
-    <section class="bg-athens-gray-white pb-0">
-      <div class="container">
-        <div class="row">
+    <section class="bg-athens-gray-white pb-5">
+        <div class="container">
+          <div class="row">
+            <div class="col-12 text-center">
+              <h3 class="header-fancy">
+                <span>Search the Docs</span>
+              </h3>
+            </div>
+            <div class="col-12 text-center pb-5">
+            <!--  <div class="resources-search"> -->
+            <!-- <input type="text" class="resources-search-input" placeholder="Search the documentation" value="">
+            <button type="submit">Search</button> -->
+    
+            <script async src="https://cse.google.com/cse.js?cx=002929300794741444210:sy0sz3qlwdc"></script>
+            <div class="gcse-searchbox-only" enableAutoComplete="true" data-resultsUrl="/search/"></div>
+            <!-- </div> -->
+          </div>
+        </div><div class="row">
           <div class="col-12 text-center">
             <h3 class="header-fancy">
               <span>Additional Resources</span>
@@ -156,15 +171,6 @@
               </div>
             </div>
           </div>
-        <div class="col-12 mt-5">
-            <!-- <div class="resources-search"> -->
-              <!-- <input type="text" class="resources-search-input" placeholder="Search the documentation" value="">
-              <button type="submit">Search</button> -->
-
-              <script async src="https://cse.google.com/cse.js?cx=002929300794741444210:sy0sz3qlwdc"></script>
-              <div class="gcse-searchbox-only" enableAutoComplete="true" data-resultsUrl="/search/"></div>
-            <!-- </div> -->
-          </div>
         </div>
       </div>
     </section>
@@ -173,7 +179,7 @@
           <div class="row">
             <div class="col-12 text-center">
               <h3 class="header-fancy">
-                <span>Additional Products and Resources</span>
+                <span>Additional Products and Content</span>
               </h3>
             </div>
             <div class="col-sm-12 col-md-6 col-lg-4">


### PR DESCRIPTION
The `netq bootstrap worker` command does not take an interface name.
Moved the search box on the landing page above the fold.