### PR TITLE
dhcpd.conf doesn't use = syntax

### DIFF
--- a/content/cumulus-linux-37/Layer-1-and-Switch-Ports/DHCP-Servers.md
+++ b/content/cumulus-linux-37/Layer-1-and-Switch-Ports/DHCP-Servers.md
@@ -119,8 +119,8 @@ Edit the `/etc/dhcp/dhcpd.conf` file and add the interface name `ifname`
 to assign an IP address through DHCP. The following provides an example:
 
     host myhost {
-         ifname = "swp1" ;
-         fixed_address = 10.10.10.10 ;
+         ifname "swp1" ;
+         fixed_address 10.10.10.10 ;
     }
 
 ## Troubleshooting

--- a/content/cumulus-linux-40/Layer-1-and-Switch-Ports/DHCP-Servers.md
+++ b/content/cumulus-linux-40/Layer-1-and-Switch-Ports/DHCP-Servers.md
@@ -103,8 +103,8 @@ Edit the `/etc/dhcp/dhcpd.conf` file and add the interface name `ifname` to assi
 
 ```
 host myhost {
-    ifname = "swp1" ;
-    fixed_address = 10.10.10.10 ;
+    ifname "swp1" ;
+    fixed_address 10.10.10.10 ;
 }
 ```
 


### PR DESCRIPTION
Ticket: PR 794
Reviewed By:
Testing Done:

Migrating PR 794 to 4.0 and 3.7 docs as well.