### PR TITLE
Port PR 806 to 4.x docs

### DIFF
--- a/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Network-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
+++ b/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Network-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
@@ -72,6 +72,7 @@ You can set up the collectors and variables on each switch.
 Edit the `/etc/hsflowd.conf` file to set up your collectors and sampling rates in `/etc/hsflowd.conf`. For example:
 
 ```
+sflow {
 # ====== Sampling/Polling/Collectors ======
   # EITHER: automatic (DNS SRV+TXT from _sflow._udp):
   #   DNS-SD { }
@@ -92,6 +93,7 @@ Edit the `/etc/hsflowd.conf` file to set up your collectors and sampling rates i
   #   collectors:
   collector { ip=192.0.2.100 udpport=6343 }
   collector { ip=192.0.2.200 udpport=6344 }
+}
 ```
 
 This configuration polls the counters every 20 seconds, samples 1 of every 40000 packets for 40G interfaces, and sends this information to a collector at 192.0.2.100 on port 6343 and to another collector at 192.0.2.200 on port 6344.

--- a/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Network-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
+++ b/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Network-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
@@ -72,6 +72,7 @@ You can set up the collectors and variables on each switch.
 Edit the `/etc/hsflowd.conf` file to set up your collectors and sampling rates in `/etc/hsflowd.conf`. For example:
 
 ```
+sflow {
 # ====== Sampling/Polling/Collectors ======
   # EITHER: automatic (DNS SRV+TXT from _sflow._udp):
   #   DNS-SD { }
@@ -92,6 +93,7 @@ Edit the `/etc/hsflowd.conf` file to set up your collectors and sampling rates i
   #   collectors:
   collector { ip=192.0.2.100 udpport=6343 }
   collector { ip=192.0.2.200 udpport=6344 }
+}
 ```
 
 This configuration polls the counters every 20 seconds, samples 1 of every 40000 packets for 40G interfaces, and sends this information to a collector at 192.0.2.100 on port 6343 and to another collector at 192.0.2.200 on port 6344.

--- a/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Network-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
+++ b/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Network-Troubleshooting/Monitoring-System-Statistics-and-Network-Traffic-with-sFlow.md
@@ -72,6 +72,7 @@ You can set up the collectors and variables on each switch.
 Edit the `/etc/hsflowd.conf` file to set up your collectors and sampling rates in `/etc/hsflowd.conf`. For example:
 
 ```
+sflow {
 # ====== Sampling/Polling/Collectors ======
   # EITHER: automatic (DNS SRV+TXT from _sflow._udp):
   #   DNS-SD { }
@@ -92,6 +93,7 @@ Edit the `/etc/hsflowd.conf` file to set up your collectors and sampling rates i
   #   collectors:
   collector { ip=192.0.2.100 udpport=6343 }
   collector { ip=192.0.2.200 udpport=6344 }
+}
 ```
 
 This configuration polls the counters every 20 seconds, samples 1 of every 40000 packets for 40G interfaces, and sends this information to a collector at 192.0.2.100 on port 6343 and to another collector at 192.0.2.200 on port 6344.


### PR DESCRIPTION
Ticket: PR 806
Reviewed By:
Testing Done:

PR 806 was made only to 3.7; ported the change to 4.0, 4.1 and 4.2.