### PR TITLE
Clarify PBR doesn't work on mgmt interfaces

### DIFF
--- a/content/cumulus-linux-40/Layer-3/Policy-based-Routing.md
+++ b/content/cumulus-linux-40/Layer-3/Policy-based-Routing.md
@@ -16,7 +16,7 @@ Policy-based routing is applied to incoming packets. All packets received on a P
 - You can apply only one PBR policy per input interface.
 - You can match on *source* and *destination* IP address only.
 - PBR is not supported for GRE or VXLAN tunneling.
-- PBR is not supported on ethernet interfaces.
+- PBR is not supported on management interfaces, such as eth0.
 - A PBR rule cannot contain both IPv4 and IPv6 addresses.
 
 {{%/notice%}}

--- a/content/cumulus-linux-41/Layer-3/Policy-based-Routing.md
+++ b/content/cumulus-linux-41/Layer-3/Policy-based-Routing.md
@@ -16,7 +16,7 @@ Policy-based routing is applied to incoming packets. All packets received on a P
 - You can apply only one PBR policy per input interface.
 - You can match on *source* and *destination* IP address only.
 - PBR is not supported for GRE or VXLAN tunneling.
-- PBR is not supported on ethernet interfaces.
+- PBR is not supported on management interfaces, such as eth0.
 - A PBR rule cannot contain both IPv4 and IPv6 addresses.
 
 {{%/notice%}}

--- a/content/cumulus-linux-42/Layer-3/Policy-based-Routing.md
+++ b/content/cumulus-linux-42/Layer-3/Policy-based-Routing.md
@@ -16,7 +16,7 @@ Policy-based routing is applied to incoming packets. All packets received on a P
 - You can apply only one PBR policy per input interface.
 - You can match on *source* and *destination* IP address only.
 - PBR is not supported for GRE or VXLAN tunneling.
-- PBR is not supported on ethernet interfaces.
+- PBR is not supported on management interfaces, such as eth0.
 - A PBR rule cannot contain both IPv4 and IPv6 addresses.
 
 {{%/notice%}}


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Policy-based routing is not supported on management interfaces, such as eth0 (as opposed to "ethernet interfaces").