### PR TITLE
Update Switch-Port-Attributes.md

### DIFF
--- a/content/cumulus-linux-41/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
+++ b/content/cumulus-linux-41/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
@@ -119,7 +119,7 @@ You can configure ports to one speed less than their maximum speed.
 | 1G               | 100 Mb                                                    |
 | 10G              | 1 Gigabit (1000 Mb)                                       |
 | 40G              | 10G\*                                                     |
-| 100G             | 50G\* & 40G (with or without breakout port), 25G\*, 10G\* |
+| 100G             | 50G\* (with or without breakout port), 25G\*, 10G\*       |
 
 \* Requires the port to be converted into a breakout port. See {{<link url="#breakout-ports" text="Configure Breakout Ports">}} below.
 
@@ -863,7 +863,7 @@ Setting the default MTU also applies to the management interface. Be sure to add
 
 Cumulus Linux lets you:
 
-- Break out 100G switch ports into 2x50G, 2x40G, 4x25G, or 4x10G with breakout cables.
+- Break out 100G switch ports into 2x50G, 4x25G, or 4x10G with breakout cables.
 - Break out 40G switch ports into four separate 10G ports for use with breakout cables.
 - Combine (*aggregate* or *gang*) four 10G switch ports into one 40G port for use with a breakout cable ({{<link url="Bonding-Link-Aggregation" text="not to be confused with a bond">}}).
 


### PR DESCRIPTION
As per @mbrownatcumulus we don't support 100G interfaces being set to 40G, or broken out to 2x40G.