### PR TITLE
changed config for RFC 5227 in Layer-3 > ARP section

### DIFF
--- a/content/cumulus-linux-37/Layer-3/Address-Resolution-Protocol-ARP.md
+++ b/content/cumulus-linux-37/Layer-3/Address-Resolution-Protocol-ARP.md
@@ -253,6 +253,7 @@ The configuration above takes effect immediately but does not persist if you reb
     ```
     cumulus@switch:~$  sudo nano /etc/cumulus/neighmgr.conf
 
+    [main]
     setsrcipv4: 10.1.0.2
     ```
 

--- a/content/cumulus-linux-40/Layer-3/Address-Resolution-Protocol-ARP.md
+++ b/content/cumulus-linux-40/Layer-3/Address-Resolution-Protocol-ARP.md
@@ -274,6 +274,7 @@ The configuration above takes effect immediately but does not persist if you reb
     ```
     cumulus@switch:~$  sudo nano /etc/cumulus/neighmgr.conf
 
+    [main]
     setsrcipv4: 10.1.0.2
     ```
 

--- a/content/cumulus-linux-41/Layer-3/Address-Resolution-Protocol-ARP.md
+++ b/content/cumulus-linux-41/Layer-3/Address-Resolution-Protocol-ARP.md
@@ -268,6 +268,7 @@ The configuration above takes effect immediately but does not persist if you reb
     ```
     cumulus@switch:~$  sudo nano /etc/cumulus/neighmgr.conf
 
+    [main]
     setsrcipv4: 10.1.0.2
     ```
 

--- a/content/cumulus-linux-42/Layer-3/Address-Resolution-Protocol-ARP.md
+++ b/content/cumulus-linux-42/Layer-3/Address-Resolution-Protocol-ARP.md
@@ -268,6 +268,7 @@ The configuration above takes effect immediately but does not persist if you reb
     ```
     cumulus@switch:~$  sudo nano /etc/cumulus/neighmgr.conf
 
+    [main]
     setsrcipv4: 10.1.0.2
     ```
 


### PR DESCRIPTION
related section:
https://docs.cumulusnetworks.com/cumulus-linux-41/Layer-3/Address-Resolution-Protocol-ARP/#duplicate-address-detection-windows-hosts

added a `[main]` section to the persistent config file /etc/cumulus/neighmgr.conf
without the proper syntax neighmgrd crashes. 