### PR TITLE
Open external links in a new window

### DIFF
--- a/themes/netDocs/layouts/shortcodes/exlink.html
+++ b/themes/netDocs/layouts/shortcodes/exlink.html
@@ -1,8 +1,8 @@
 {{- if .Get "url" -}}
 {{- if or (in (.Get "url") "mailto:") (in (.Get "url")  "//")  -}}
-        <a rel="canonical" href="{{ (.Get "url") }}">{{- default (.Get "url") (.Get "text") -}}</a>
+        <a rel="canonical" href="{{ (.Get "url") }}" target="_blank">{{- default (.Get "url") (.Get "text") -}}</a>
     {{- else -}} 
-        <a rel="canonical" href="//{{ (.Get "url") }}">{{- default (.Get "url") (.Get "text") -}}</a>
+        <a rel="canonical" href="//{{ (.Get "url") }}" target="_blank">{{- default (.Get "url") (.Get "text") -}}</a>
     {{- end -}} 
 {{- else -}}
     {{ errorf "missing url in link %s" .Position}}


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done: tested some exlinks in docs and they all opened in new tabs.

Add `target="_blank"` to the exlink shortcode so all external links open in a new tab.