### PR TITLE
Update docs for cl-acltool -i

### DIFF
--- a/content/cumulus-linux-37/System-Configuration/Netfilter-ACLs/_index.md
+++ b/content/cumulus-linux-37/System-Configuration/Netfilter-ACLs/_index.md
@@ -776,10 +776,15 @@ Install all ACL policies under a directory:
     Installing acl policy ...
     Done.
 
-Install all rules and policies included in
+Apply all rules and policies included in
 `/etc/cumulus/acl/policy.conf`:
 
     cumulus@switch:~$ sudo cl-acltool -i
+
+In addition to ensuring that the rules and policies referenced by
+`/etc/cumulus/acl/policy.conf` are installed, this will remove any
+currently active rules and policies that are not contained in the
+files referenced by `/etc/cumulus/acl/policy.conf`.  
 
 ## Specify the Policy Files to Install
 


### PR DESCRIPTION
Make it clear that `cl-acltool -i` is not strictly additive, and will remove rules and policies that it does not find in the config files.