### PR TITLE
Remove forum references

### DIFF
--- a/content/contributor-guide/Resources/Markdown_Guide.md
+++ b/content/contributor-guide/Resources/Markdown_Guide.md
@@ -25,7 +25,7 @@ This type of link is used to reference content outside of the documentation site
 
 | Inline Markdown | Example |
 | -------------------- | ---------- |
-| \[Display Text\](\<site-address\>) | \[Cumulus Forums\](http://forums.cumulusnetworks.com) |
+| \[Display Text\](\<site-address\>) | \[Cumulus docs\](http://docs.cumulusnetworks.com) |
 
 {{% notice note %}}
 Do not use traditional markdown links to link between pages in the documentation. Use the custom `link` shortcode to to link between internal documentation pages.

--- a/content/cumulus-vx/Cumulus-VX-Support-Policy.md
+++ b/content/cumulus-vx/Cumulus-VX-Support-Policy.md
@@ -34,10 +34,4 @@ Cumulus Networks does *not* provide support for the following:
   - Performance or scalability issues related to network traffic running
     through Cumulus VX instances.
 
-For non-customers, Cumulus VX remains a community-supported product,
-with no formal support obligations from Cumulus Networks. You can submit
-questions to the 
-[Cumulus Networks community forums](https://forums.cumulusnetworks.com) 
-(hosted and moderated by Cumulus Networks) or to the 
-[community Slack channel](https://slack.cumulusnetworks.com/) to engage with 
-the forums and wider community.
+For non-customers, Cumulus VX remains a community-supported product, with no formal support obligations from Cumulus Networks. You can submit questions to the [community Slack channel](https://slack.cumulusnetworks.com/) to engage with the wider community.

--- a/content/cumulus-vx/Next-Steps.md
+++ b/content/cumulus-vx/Next-Steps.md
@@ -116,9 +116,5 @@ This command updates both the `/etc/hostname` and `/etc/hosts` files.
 Check out these community articles and the rest of the Cumulus Linux
 documentation:
 
-  - [Automation: Network automation with Cumulus VX](https://forums.cumulusnetworks.com/cumulus-vx-230884/testing-network-automation-with-cumulus-vx-6727777)
-  - [Routing protocols: Unnumbered OSPF/BGP with Cumulus VX](https://forums.cumulusnetworks.com/cumulus-vx-230884/unnumbered-ospf-bgp-configuration-on-vmware-esxi-with-cumulus-vx-6728629)
-  - [Network redundancy: Multi-chassis Link Aggregation (MLAG) with Cumulus VX](https://forums.cumulusnetworks.com/cumulus-vx-230884/spinning-up-a-virtual-mlag-environment-6722798)
-  - [Network virtualization: Cumulus VX with VMware NSX](https://forums.cumulusnetworks.com/cumulus-vx-230884/integrating-cumulus-vx-with-vmware-nsx-using-vmware-esxi-6732766)
   - [Cumulus Linux documentation](/cumulus-linux)
   - [Cumulus Networks knowledge base](https://support.cumulusnetworks.com/hc/en-us/)

--- a/themes/netDocs/layouts/home.html
+++ b/themes/netDocs/layouts/home.html
@@ -47,7 +47,7 @@
           <li><a href="//docs.cumulusnetworks.com/">DOCS</a></li>
           <li><a href="//education.cumulusnetworks.com/">EDUCATION</a></li>
           <li><a href="//cumulusnetworks.com/blog/">BLOG</a></li>
-          <li><a href="//forums.cumulusnetworks.com/">FORUMS</a></li>
+          <li><a href="//slack.cumulusnetworks.com/">COMMUNITY</a></li>
         </ul>
         <div class="burger-menu">
           <span></span>

--- a/themes/netDocs/layouts/partials/footer-javascript.html
+++ b/themes/netDocs/layouts/partials/footer-javascript.html
@@ -41,8 +41,3 @@
         s.parentNode.insertBefore(gd, s);
     })();
 </script>
-
-<!-- insided forums menu --> 
-<script>
-    (function(w,d,s){var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src='//embeddable-widgets-usw2.insided.com/cumulusnetworks-en.insided-conversational.js';f.parentNode.insertBefore(j,f);})(window,document,'script');
-</script>

--- a/themes/netDocs/layouts/partials/top-header.html
+++ b/themes/netDocs/layouts/partials/top-header.html
@@ -11,7 +11,7 @@
             <li><a href="//docs.cumulusnetworks.com/">DOCS</a></li>
             <li><a href="//education.cumulusnetworks.com/">EDUCATION</a></li>
             <li><a href="//cumulusnetworks.com/blog/">BLOG</a></li>
-            <li><a href="//forums.cumulusnetworks.com/">FORUMS</a></li>
+            <li><a href="//slack.cumulusnetworks.com/">COMMUNITY</a></li>
         </ul>
         <div class="burger-menu">
             <span>  </span>

--- a/themes/netDocs/layouts/search/search.html
+++ b/themes/netDocs/layouts/search/search.html
@@ -41,7 +41,7 @@
           <li><a href="//docs.cumulusnetworks.com/">DOCS</a></li>
           <li><a href="//education.cumulusnetworks.com">EDUCATION</a></li>
           <li><a href="//cumulusnetworks.com/blog/">BLOG</a></li>
-          <li><a href="//forums.cumulusnetworks.com/">FORUMS</a></li>
+          <li><a href="//slack.cumulusnetworks.com/">COMMUNITY</a></li>
         </ul>
         <div class="burger-menu">
           <span></span>


### PR DESCRIPTION
UD-2060

Remove links to the forums since they've been decommissioned. Replace with links to Slack as appropriate.