### PR TITLE
Update Docker-on-Cumulus-Linux.md

### DIFF
--- a/content/cumulus-linux-37/Network-Solutions/Docker-on-Cumulus-Linux.md
+++ b/content/cumulus-linux-37/Network-Solutions/Docker-on-Cumulus-Linux.md
@@ -96,7 +96,7 @@ Install Docker:
 6.  In a text editor, create a file called `/etc/docker/daemon.json`, add
     the following line to it, then save the file:
 
-        cumulus@switch:$ sudo nano /etc/systemd/system/docker.service.d/noiptables-mgmt-vrf.conf
+        cumulus@switch:$ sudo nano /etc/docker/daemon.json
 
         {"exec-opts": ["native.cgroupdriver=systemd"]}
 


### PR DESCRIPTION
This page was out of date, providing links to a deprecated docker repo & old GPG keys.
There were also a handful of issues where the instructions provided simply didn't work, namely use of the mgmt VRF.

I've updated this to use the proper repo & GPG key (as per Docker's instruction page).
Additionally, I've adjusted the configuration procedure to ensure docker will run successfully (in the mgmt VRF as well).