### PR TITLE
Update Setting-Date-and-Time.md

### DIFF
--- a/content/cumulus-linux-41/System-Configuration/Setting-Date-and-Time.md
+++ b/content/cumulus-linux-41/System-Configuration/Setting-Date-and-Time.md
@@ -24,6 +24,12 @@ US/Eastern
 
 Edit the file to add your desired time zone. A list of valid time zones can be found {{<exlink url="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones" text="here">}}.
 
+Use the following command to change the /etc/localtime to reflect your current timezone. Use the same value as the previous step.
+
+```
+sudo ln -sf /usr/share/zoneinfo/US/Eastern /etc/localtime
+```
+
 Use the following command to apply the new time zone immediately.
 
 ```


### PR DESCRIPTION
If localtime is not set, then this command will just reset the timezone back to UTC:

```
bhohnke@globleaf21:mgmt:~$ cat /etc/timezone
Australia/Sydney
bhohnke@globleaf21:mgmt:~$ sudo su
root@globleaf21:mgmt:/home/bhohnke# dpkg-reconfigure --frontend noninteractive tzdata
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_TERMINAL = "iTerm2",
	LC_CTYPE = "en_AU.UTF-8",
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to a fallback locale ("en_US.UTF-8").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory

Current default time zone: 'Etc/UTC'
Local time is now:      Thu Jul 16 05:40:54 UTC 2020.
Universal Time is now:  Thu Jul 16 05:40:54 UTC 2020.

root@globleaf21:mgmt:/home/bhohnke# exit
bhohnke@globleaf21:mgmt:~$ cat /etc/timezone
Etc/UTC
bhohnke@globleaf21:mgmt:~$ sudo vim /etc/timezone
bhohnke@globleaf21:mgmt:~$ cat /etc/timezone
Australia/Sydney
bhohnke@globleaf21:mgmt:~$ sudo ln -sf /usr/share/zoneinfo/Australia/Sydney /etc/localtime
bhohnke@globleaf21:mgmt:~$ sudo dpkg-reconfigure --frontend noninteractive tzdata
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_TERMINAL = "iTerm2",
	LC_CTYPE = "en_AU.UTF-8",
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to a fallback locale ("en_US.UTF-8").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory

Current default time zone: 'Australia/Sydney'
Local time is now:      Thu Jul 16 15:43:29 AEST 2020.
Universal Time is now:  Thu Jul 16 05:43:29 UTC 2020.

bhohnke@globleaf21:mgmt:~$ cat /etc/timezone
Australia/Sydney
```