### PR TITLE
Remove mention of snmpd from VRF chapter

### DIFF
--- a/content/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -222,8 +222,6 @@ In Cumulus Linux, the following services work with VRF instances:
   - netq-agent
   - ntp
   - puppet
-  - snmpd
-  - snmptrapd
   - ssh
   - zabbix-agent
 
@@ -1064,7 +1062,7 @@ non-default VRF table using the `dhcpd` and `dhcrelay` services,
 respectively. These services must be managed by `systemd` in order to
 run in a VRF context; in addition, the services must be listed in
 `/etc/vrf/systemd.conf`. By default, this file already lists these two
-services, as well as others like `ntp` and `snmpd`. You can add more
+services, as well as others like `ntp`. You can add more
 services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
 
 If you edit `/etc/vrf/systemd.conf`, run `sudo systemctl daemon-reload`

--- a/content/cumulus-linux-37/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-37/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -223,8 +223,6 @@ In Cumulus Linux, the following services work with VRF instances:
 - netq-agent
 - ntp
 - puppet
-- snmpd
-- snmptrapd
 - ssh
 - zabbix-agent
 
@@ -1238,7 +1236,7 @@ non-default VRF table using the `dhcpd` and `dhcrelay` services,
 respectively. These services must be managed by `systemd` in order to
 run in a VRF context; in addition, the services must be listed in
 `/etc/vrf/systemd.conf`. By default, this file already lists these two
-services, as well as others like `ntp` and `snmpd`. You can add more
+services, as well as others like `ntp`. You can add more
 services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
 
 If you edit `/etc/vrf/systemd.conf`, run `sudo systemctl daemon-reload`

--- a/content/cumulus-linux-41/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-41/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -211,8 +211,6 @@ The following services work with VRF instances:
 - `netq-agent`
 - `ntp`
 - `puppet`
-- `snmpd`
-- `snmptrapd`
 - `ssh`
 - `zabbix-agent`
 
@@ -1207,7 +1205,7 @@ router bgp 65001 vrf vrf1
 
 ## DHCP with VRF
 
-Because you can use VRF to bind IPv4 and IPv6 sockets to non-default VRF tables, you can start DHCP servers and relays in any non-default VRF table using the `dhcpd` and `dhcrelay` services.  These services must be managed by `systemd` to run in a VRF context. In addition, the services must be listed in the `/etc/vrf/systemd.conf` file. By default, this file already lists these two services, as well as others like `ntp` and `snmpd`. You can add more services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
+Because you can use VRF to bind IPv4 and IPv6 sockets to non-default VRF tables, you can start DHCP servers and relays in any non-default VRF table using the `dhcpd` and `dhcrelay` services.  These services must be managed by `systemd` to run in a VRF context. In addition, the services must be listed in the `/etc/vrf/systemd.conf` file. By default, this file already lists these two services, as well as others like `ntp`. You can add more services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
 
 If you edit `/etc/vrf/systemd.conf`, run `sudo systemctl daemon-reload` to generate the `systemd` instance files for the newly added services. Then you can start the service in the VRF using `systemctl start <service>@<vrf-name>.service`, where `<service>` is the name of the service (such as `dhcpd` or `dhcrelay`) and `<vrf-name>` is the name of the VRF.
 

--- a/content/cumulus-linux-42/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-42/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -211,8 +211,6 @@ The following services work with VRF instances:
 - `netq-agent`
 - `ntp`
 - `puppet`
-- `snmpd`
-- `snmptrapd`
 - `ssh`
 - `zabbix-agent`
 
@@ -1207,7 +1205,7 @@ router bgp 65001 vrf vrf1
 
 ## DHCP with VRF
 
-Because you can use VRF to bind IPv4 and IPv6 sockets to non-default VRF tables, you can start DHCP servers and relays in any non-default VRF table using the `dhcpd` and `dhcrelay` services.  These services must be managed by `systemd` to run in a VRF context. In addition, the services must be listed in the `/etc/vrf/systemd.conf` file. By default, this file already lists these two services, as well as others like `ntp` and `snmpd`. You can add more services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
+Because you can use VRF to bind IPv4 and IPv6 sockets to non-default VRF tables, you can start DHCP servers and relays in any non-default VRF table using the `dhcpd` and `dhcrelay` services.  These services must be managed by `systemd` to run in a VRF context. In addition, the services must be listed in the `/etc/vrf/systemd.conf` file. By default, this file already lists these two services, as well as others like `ntp`. You can add more services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
 
 If you edit `/etc/vrf/systemd.conf`, run `sudo systemctl daemon-reload` to generate the `systemd` instance files for the newly added services. Then you can start the service in the VRF using `systemctl start <service>@<vrf-name>.service`, where `<service>` is the name of the service (such as `dhcpd` or `dhcrelay`) and `<vrf-name>` is the name of the VRF.
 


### PR DESCRIPTION
Ticket: UD-2053
Reviewed By: stannous
Testing Done:

snmpd has had native VRF support since 3.6.0.