### PR TITLE
Put snmptrapd back

### DIFF
--- a/content/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -214,16 +214,17 @@ details how to do this.
 
 In Cumulus Linux, the following services work with VRF instances:
 
-  - chef-client
-  - collectd
-  - dhcpd
-  - dhcrelay
-  - hsflowd
-  - netq-agent
-  - ntp
-  - puppet
-  - ssh
-  - zabbix-agent
+- `chef-client`
+- `collectd`
+- `dhcpd`
+- `dhcrelay`
+- `hsflowd`
+- `netq-agent`
+- `ntp`
+- `puppet`
+- `snmptrapd`
+- `ssh`
+- `zabbix-agent`
 
 {{%notice note%}}
 

--- a/content/cumulus-linux-37/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-37/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -215,16 +215,17 @@ details how to do this.
 
 In Cumulus Linux, the following services work with VRF instances:
 
-- chef-client
-- collectd
-- dhcpd
-- dhcrelay
-- hsflowd
-- netq-agent
-- ntp
-- puppet
-- ssh
-- zabbix-agent
+- `chef-client`
+- `collectd`
+- `dhcpd`
+- `dhcrelay`
+- `hsflowd`
+- `netq-agent`
+- `ntp`
+- `puppet`
+- `snmptrapd`
+- `ssh`
+- `zabbix-agent`
 
 {{%notice note%}}
 

--- a/content/cumulus-linux-40/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-40/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -210,7 +210,6 @@ The following services work with VRF instances:
 - `netq-agent`
 - `ntp`
 - `puppet`
-- `snmpd`
 - `snmptrapd`
 - `ssh`
 - `zabbix-agent`
@@ -1206,7 +1205,7 @@ router bgp 65001 vrf vrf1
 
 ## DHCP with VRF
 
-Because you can use VRF to bind IPv4 and IPv6 sockets to non-default VRF tables, you can start DHCP servers and relays in any non-default VRF table using the `dhcpd` and `dhcrelay` services.  These services must be managed by `systemd` to run in a VRF context. In addition, the services must be listed in the `/etc/vrf/systemd.conf` file. By default, this file already lists these two services, as well as others like `ntp` and `snmpd`. You can add more services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
+Because you can use VRF to bind IPv4 and IPv6 sockets to non-default VRF tables, you can start DHCP servers and relays in any non-default VRF table using the `dhcpd` and `dhcrelay` services.  These services must be managed by `systemd` to run in a VRF context. In addition, the services must be listed in the `/etc/vrf/systemd.conf` file. By default, this file already lists these two services, as well as others like `ntp`. You can add more services as needed, such as `dhcpd6` and `dhcrelay6` for IPv6.
 
 If you edit `/etc/vrf/systemd.conf`, run `sudo systemctl daemon-reload` to generate the `systemd` instance files for the newly added services. Then you can start the service in the VRF using `systemctl start <service>@<vrf-name>.service`, where `<service>` is the name of the service (such as `dhcpd` or `dhcrelay`) and `<vrf-name>` is the name of the VRF.
 

--- a/content/cumulus-linux-41/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-41/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -211,6 +211,7 @@ The following services work with VRF instances:
 - `netq-agent`
 - `ntp`
 - `puppet`
+- `snmptrapd`
 - `ssh`
 - `zabbix-agent`
 

--- a/content/cumulus-linux-42/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
+++ b/content/cumulus-linux-42/Layer-3/Virtual-Routing-and-Forwarding-VRF.md
@@ -211,6 +211,7 @@ The following services work with VRF instances:
 - `netq-agent`
 - `ntp`
 - `puppet`
+- `snmptrapd`
 - `ssh`
 - `zabbix-agent`
 


### PR DESCRIPTION
Ticket: UD-2053
Reviewed By: stannous
Testing Done:

Turns out we haven't tested native VRF support for snmptrapd, so it should stay on this list.