### PR TITLE
more KB migration stuff

### DIFF
--- a/content/cumulus-linux-36/Whats-New/Cumulus-Linux-3.6-Release-Notes.md
+++ b/content/cumulus-linux-36/Whats-New/Cumulus-Linux-3.6-Release-Notes.md
@@ -1,53 +1,56 @@
 ---
 title: Cumulus Linux 3.6 Release Notes
 author: Cumulus Networks
-weight: 109
-toc: 3
+weight: 7
 ---
 
 These release notes support Cumulus Linux 3.6.0, 3.6.1, and 3.6.2 and describe currently available features and known issues.
 
 ## Stay up to Date
 
-- Subscribe to our [product bulletin](https://lists.cumulusnetworks.com/listinfo/cumulus-product-bulletin) mailing list to receive important announcements and updates about issues that arise in our products.
-- Subscribe to our [security announcement](https://lists.cumulusnetworks.com/listinfo/cumulus-security-announce) mailing list to receive alerts whenever we update our software for security issues.
+- Subscribe to our {{<exlink url="https://lists.cumulusnetworks.com/listinfo/cumulus-product-bulletin" text="product bulletin">}} mailing list to receive important announcements and updates about issues that arise in our products.
+- Subscribe to our {{<exlink url="https://lists.cumulusnetworks.com/listinfo/cumulus-security-announce" text="security announcement">}} mailing list to receive alerts whenever we update our software for security issues.
 
-## What's New in Cumulus Linux 3.6.2
+## What's New in Cumulus Linux 3.6.2
 
 Cumulus Linux 3.6.2 contains the following new features, platforms, and improvements:
 
-- [Facebook Voyager](https://cumulusnetworks.com/hcl) (DWDM) (100G Tomahawk) now generally available
-- NCLU commands available for [configuring traditional mode bridges](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-2/Ethernet-Bridging-VLANs/Traditional-Bridge-Mode/)
-- [VRF static route leaking with EVPN](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF/#configuring-static-route-leaking-with-evpn) symmetric routing
-- New [`vrf_route_leak_enable` option](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF/#enabling-vrf-route-leaking) to enable VRF route leaking
+- {{<exlink url="https://cumulusnetworks.com/hcl" text="Facebook Voyager">}} (DWDM) (100G Tomahawk) now generally available
+- NCLU commands available for {{<link url="Traditional-Bridge-Mode" text="configuring traditional mode bridges">}}
+- {{<link url="Virtual-Routing-and-Forwarding-VRF/#configuring-static-route-leaking-with-evpn" text="VRF static route leaking with EVPN">}} symmetric routing
+- New {{<link url="Virtual-Routing-and-Forwarding-VRF/#enabling-vrf-route-leaking" text="vrf_route_leak_enable option">}} used to enable VRF route leaking
+
+## What's New in Cumulus Linux 3.6.2
+
+Cumulus Linux 3.6.1 contains bug fixes and security fixes.
 
 ## What's New in Cumulus Linux 3.6.0
 
-Cumulus Linux 3.6.0 contains the following new features, platforms, and improvements:
+Cumulus Linux 3.6.0 contains a number of new platforms, features and improvements:
 
-- New [platforms](https://cumulusnetworks.com/hcl) include:
-    - Dell S4128T (10GBASE-T Maverick)
-    - Dell S5048 (25G Tomahawk+)
+- New {{<exlink url="https://cumulusnetworks.com/hcl" text="platforms">}} include:
+    - Dell S4128T-ON (10GBASE-T Maverick)
+    - Dell S5048-ON (25G Tomahawk+)
     - Delta AG-5648v1 (25G Tomahawk+)
-    - Edgecore AS7312-54XS (Tomahawk+) - also available as Cumulus Express
-    - Facebook Voyager (DWDM) (100G Tomahawk) - *Early Access*
-    - Penguin Arctica 1600CS (Spectrum 100G)
-    - Penguin Arctica 3200CS (Spectrum 100G)
-    - Penguin Arctica 4808X (Spectrum 10G)
-- [Policy-Based Routing](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-3/Policy-based-Routing/)
-- [VRF Route Leaking](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF/#vrf-route-leaking) on switches with Broadcom ASICs
-- [PTP Boundary Clock](https://docs.cumulusnetworks.com/cumulus-linux-36/System-Configuration/Setting-Date-and-Time/#precision-time-protocol-ptp-boundary-clock)
-- [GRE Tunneling](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-3/GRE-Tunneling/) (early access)
-- New [`/etc/cumulus/ports.conf` file validator](#rn873) finds syntax and platform-specific errors, and provides a reason for each invalid line.
-- Support for combination of `local-as` and `allowas-in` command
+    - Edgecore AS7312-54XS (Tomahawk+)
+    - Facebook Voyager (100G Tomahawk/DWDM) Early Access
+    - Penguin Arctica 1600CS (100G Spectrum)
+    - Penguin Arctica 3200CS (100G Spectrum)
+    - Penguin Arctica 4808X (10G Spectrum)
+- {{<link url="Policy-based-Routing" text="Policy-based routing">}}
+- {{<link url="Virtual-Routing-and-Forwarding-VRF/#vrf-route-leaking" text="VRF route leaking">}}
+- {{<link url="Setting-Date-and-Time/#precision-time-protocol-ptp-boundary-clock" text="PTP boundary clock">}} on Mellanox switches
+- {{<link url="GRE-Tunneling" text="GRE tunneling">}} on Mellanox switches
+- New {{<link url="#rn873" text="ports.conf file validator">}} finds syntax errors and provides a reason for each invalid line. Error messages are shown when you run the `net commit` command.
+- Support for the combination of the `local-as` and `allowas-in` commands
 - OSPFv3 enhancements:
     - Validated interoperability with other routers at a scale of 120 neighbors
-    - New NCLU commands to configure [OSPFv3](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-3/Open-Shortest-Path-First-v3-OSPFv3-Protocol/#configuring-the-ospfv3-area)
+    - New NCLU commands to configure {{<link url="Open-Shortest-Path-First-v3-OSPFv3-Protocol/#configuring-the-ospfv3-area" text="OSPFv3">}}
 - EVPN Enhancements:
-    - [Type-5 routes with asymmetric routing](https://docs.cumulusnetworks.com/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#evpn-type-5-routing-with-asymmetric-routing)
-    - [Default originate EVPN Type-5 Routes](https://docs.cumulusnetworks.com/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#originating-default-evpn-type-5-routes)
-    - [Filter EVPN routes based on type](https://docs.cumulusnetworks.com/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#filtering-evpn-routes-based-on-type)
-    - [Control which RIB routes are injected into EVPN](https://docs.cumulusnetworks.com/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#controlling-which-rib-routes-are-injected-into-evpn)
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#evpn-type-5-routing-with-asymmetric-routing" text="Type-5 routes with asymmetric routing">}}
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#originating-default-evpn-type-5-routes" text="Originate default EVPN type-5 routes">}}
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#filtering-evpn-routes-based-on-type" text="Filter EVPN routes based on type">}}
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#controlling-which-rib-routes-are-injected-into-evpn" text="Control which RIB routes are injected into EVPN">}}
 - Cumulus Linux 3.6 is the last release to support Quanta IX2 (25G Tomahawk)
 
 ## Licensing
@@ -59,13 +62,11 @@ and console ports are activated on an un-licensed instance of Cumulus
 Linux. Enabling front panel ports requires a license.
 
 You should have received a license key from Cumulus Networks or an
-authorized reseller. To install the license, read the Cumulus Linux
-[Quick Start Guide](https://docs.cumulusnetworks.com/cumulus-linux-36/Quick-Start-Guide/).
+authorized reseller. To install the license, read the {{<link url="Quick-Start-Guide">}}.
 
 ## Installing Version 3.6
 
-If you are upgrading from version 3.0.0 or later, use
-[`apt-get`](https://wiki.debian.org/apt-get) to update the software.
+If you are upgrading from version 3.0.0 or later, use {{<exlink url="https://wiki.debian.org/apt-get" text="apt-get">}} to update the software.
 
 Cumulus Networks recommends you use the `-E` option with `sudo` whenever
 you run any `apt-get` command. This option preserves your environment
@@ -73,7 +74,7 @@ variables, such as HTTP proxies, before you install new packages or
 upgrade your distribution.
 
 1.  Retrieve the new version packages: `cumulus@switch:~$ sudo -E apt-get update`
-2.  If you are using any [early access features](https://docs.cumulusnetworks.com/knowledge-base/Support/Support-Offerings/Early-Access-Features-Defined/) from an older release, remove them with: `cumulus@switch:~$ sudo -E apt-get remove EA_PACKAGENAME`
+2.  If you are using any {{<exlink url="https://docs.cumulusnetworks.com/knowledge-base/Support/Support-Offerings/Early-Access-Features-Defined/" text="early access features">}} from an older release, remove them with: `cumulus@switch:~$ sudo -E apt-get remove EA_PACKAGENAME`
 3.  Upgrade the release: `cumulus@switch:~$ sudo -E apt-get upgrade`
 4.  To include additional Cumulus Linux packages not present in your current version, run the command: `cumulus@switch:~$ apt-get install nclu hostapd python-cumulus-restapi linuxptp` 
 
@@ -82,7 +83,7 @@ upgrade your distribution.
 
 {{%notice note%}}
 
-If you see errors for expired GPG keys that prevent you from upgrading packages when upgrading to Cumulus Linux 3.6 from 3.5.1 or earlier, follow the steps in [Upgrading Expired GPG Keys](https://docs.cumulusnetworks.com/knowledge-base/Installing-and-Upgrading/Upgrading/Update-Expired-GPG-Keys/).
+If you see errors for expired GPG keys that prevent you from upgrading packages when upgrading to Cumulus Linux 3.6 from 3.5.1 or earlier, follow the steps in {{<exlink url="https://docs.cumulusnetworks.com/knowledge-base/Installing-and-Upgrading/Upgrading/Update-Expired-GPG-Keys/" text="Upgrading Expired GPG Keys">}}.
 
 {{%/notice%}}
 
@@ -113,12 +114,12 @@ For upgrades post 3.6.0, if no reboot is required after the upgrade completes, t
     Policy: Removed /usr/sbin/policy-rc.d
     Policy: Upgrade is finished
 
-For additional information about upgrading, see [Upgrading Cumulus Linux](https://docs.cumulusnetworks.com/cumulus-linux-36/Installation-Management/Upgrading-Cumulus-Linux/) in the *Cumulus Linux User Guide*.
+For additional information about upgrading, see {{<link url="Upgrading-Cumulus-Linux" text="Upgrading Cumulus Linux">}}.
 
 ### New Install or Upgrading from Versions Older than 3.0.0
 
 If you are upgrading from a version older than 3.0.0, or installing
-Cumulus Linux for the first time, download the [Cumulus Linux 3.6.0 installer](https://cumulusnetworks.com/downloads/) for Broadcom or Mellanox switches from the Cumulus Networks website, then use [ONIE](http://onie.github.io/onie/) to perform a complete install, following the instructions in the [quick start guide](https://docs.cumulusnetworks.com/cumulus-linux-36/Quick-Start-Guide/).
+Cumulus Linux for the first time, download the {{<exlink url="https://cumulusnetworks.com/downloads/" text="Cumulus Linux 3.6.0 installer">}} for Broadcom or Mellanox switches from the Cumulus Networks website, then use {{<exlink url="http://onie.github.io/onie/" text="ONIE">}} to perform a complete install, following the instructions in the {{<link url="Quick-Start-Guide">}}.
 
 {{%notice note%}}
 
@@ -134,7 +135,7 @@ After you install, run `apt-get update`, then `apt-get upgrade` on your switch t
 
 ### Updating a Deployment that Has MLAG Configured
 
-If you are using [MLAG](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-2/Multi-Chassis-Link-Aggregation-MLAG/) to dual connect two switches in your environment, and those switches are still running Cumulus Linux 2.5 ESR or any other release earlier than 3.0.0, the switches will not be dual-connected after you upgrade the first switch. To ensure a smooth upgrade, follow these steps:
+If you are using {{<link url="Multi-Chassis-Link-Aggregation-MLAG" text="MLAG">}} to dual connect two switches in your environment, and those switches are still running Cumulus Linux 2.5 ESR or any other release earlier than 3.0.0, the switches will not be dual-connected after you upgrade the first switch. To ensure a smooth upgrade, follow these steps:
 
 1.  Disable `clagd` in the `/etc/network/interfaces` file (set `clagd-enable` to *no*), then restart the `switchd`, networking, and FRR services.  
 
@@ -161,7 +162,7 @@ If you are using [MLAG](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-
 6.  Install Cumulus Linux 3.6 onto the secondary switch using ONIE. At
     this time, all traffic is going to the switch in the primary role.
 
-7.  After the install, copy the license file and all the [configuration files](https://docs.cumulusnetworks.com/cumulus-linux-36/Installation-Management/Upgrading-Cumulus-Linux/) you backed up, then restart the `switchd`, networking, and Quagga services. All traffic is still going to the primary switch.  
+7.  After the install, copy the license file and all the {{<link url="Upgrading-Cumulus-Linux" text="configuration files">}} you backed up, then restart the `switchd`, networking, and Quagga services. All traffic is still going to the primary switch.  
 
         cumulus@switch:~$ sudo systemctl restart switchd.service
         cumulus@switch:~$ sudo systemctl restart networking.service
@@ -171,9 +172,9 @@ If you are using [MLAG](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-
 
 9.  Install Cumulus Linux 3.6 onto the *primary switch* using ONIE.
 
-10. After the install, copy the license file and all the [configuration files](https://docs.cumulusnetworks.com/cumulus-linux-36/Installation-Management/Upgrading-Cumulus-Linux/) you backed up.
+10. After the install, copy the license file and all the {{<link url="Upgrading-Cumulus-Linux" text="configuration files">}} you backed up.
 
-11. Follow the steps for [upgrading from Quagga to FRRouting](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-3/FRRouting-Overview/Upgrading-from-Quagga-to-FRRouting/).
+11. Follow the steps for {{<link url="Upgrading-from-Quagga-to-FRRouting" text="upgrading from Quagga to FRRouting">}}.
 
 12. Enable `clagd` again in the `/etc/network/interfaces` file (set
     `clagd-enable` to *yes*), then run `ifreload -a`.  
@@ -193,10 +194,6 @@ If you are using [MLAG](https://docs.cumulusnetworks.com/cumulus-linux-36/Layer-
 Any Perl scripts that use the `DB_File` module or Python scripts that use the `bsddb` module won't run under Cumulus Linux 3.6.
 
 {{%/notice%}}
-
-## Documentation
-
-You can read the technical documentation [here](https://docs.cumulusnetworks.com/cumulus-linux-36/).
 
 ## Issues Fixed in Cumulus Linux 3.6.2
 

--- a/content/cumulus-linux-36/Whats-New/_index.md
+++ b/content/cumulus-linux-36/Whats-New/_index.md
@@ -1,0 +1,54 @@
+---
+title: What's New
+author: Cumulus Networks
+weight: 5
+---
+
+This document supports the Cumulus Linux 3.6 releases, and lists new platforms and features.
+
+- For a list of all the platforms supported in a Cumulus Linux 3.6 release, see the {{<exlink url="https://cumulusnetworks.com/hcl" text="Hardware Compatibility List (HCL)">}}.
+- For a list of open and fixed issues in Cumulus Linux 3.6, see the {{<link url="Cumulus-Linux-3.6-Release-Notes">}}.
+- To upgrade to a Cumulus Linux 3.6 release, follow the steps in {{<link url="Upgrading-Cumulus-Linux">}}.
+
+## What's New in Cumulus Linux 3.6.2
+
+Cumulus Linux 3.6.2 contains the following new features, platforms, and improvements:
+
+- {{<exlink url="https://cumulusnetworks.com/hcl" text="Facebook Voyager">}} (DWDM) (100G Tomahawk) now generally available
+- NCLU commands available for {{<link url="Traditional-Bridge-Mode" text="configuring traditional mode bridges">}}
+- {{<link url="Virtual-Routing-and-Forwarding-VRF/#configuring-static-route-leaking-with-evpn" text="VRF static route leaking with EVPN">}} symmetric routing
+- New {{<link url="Virtual-Routing-and-Forwarding-VRF/#enabling-vrf-route-leaking" text="vrf_route_leak_enable option">}} used to enable VRF route leaking
+
+## What's New in Cumulus Linux 3.6.2
+
+Cumulus Linux 3.6.1 contains bug fixes and security fixes.
+
+## What's New in Cumulus Linux 3.6.0
+
+Cumulus Linux 3.6.0 contains a number of new platforms, features and improvements:
+
+- New {{<exlink url="https://cumulusnetworks.com/hcl" text="platforms">}} include:
+    - Dell S4128T-ON (10GBASE-T Maverick)
+    - Dell S5048-ON (25G Tomahawk+)
+    - Delta AG-5648v1 (25G Tomahawk+)
+    - Edgecore AS7312-54XS (Tomahawk+)
+    - Facebook Voyager (100G Tomahawk/DWDM) Early Access
+    - Penguin Arctica 1600CS (100G Spectrum)
+    - Penguin Arctica 3200CS (100G Spectrum)
+    - Penguin Arctica 4808X (10G Spectrum)
+- {{<link url="Policy-based-Routing" text="Policy-based routing">}}
+- {{<link url="Virtual-Routing-and-Forwarding-VRF/#vrf-route-leaking" text="VRF route leaking">}}
+- {{<link url="Setting-Date-and-Time/#precision-time-protocol-ptp-boundary-clock" text="PTP boundary clock">}} on Mellanox switches
+- {{<link url="GRE-Tunneling" text="GRE tunneling">}} on Mellanox switches
+- New `/etc/cumulus/ports.conf` file validator finds syntax errors and provides a reason for each invalid line. Error messages are shown when you run the `net commit` command.
+- Support for the combination of the `local-as` and `allowas-in` commands
+- OSPFv3 enhancements:
+    - Validated interoperability with other routers at a scale of 120 neighbors
+    - New NCLU commands to configure {{<link url="Open-Shortest-Path-First-v3-OSPFv3-Protocol/#configuring-the-ospfv3-area" text="OSPFv3">}}
+- EVPN Enhancements:
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#evpn-type-5-routing-with-asymmetric-routing" text="Type-5 routes with asymmetric routing">}}
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#originating-default-evpn-type-5-routes" text="Originate default EVPN type-5 routes">}}
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#filtering-evpn-routes-based-on-type" text="Filter EVPN routes based on type">}}
+    - {{<link url="Ethernet-Virtual-Private-Network-EVPN/#controlling-which-rib-routes-are-injected-into-evpn" text="Control which RIB routes are injected into EVPN">}}
+
+For information on bug fixes and known issues present in this release, refer to the {{<link url="Cumulus-Linux-3.6-Release-Notes/" text="product release notes">}}.

--- a/content/cumulus-linux-36/_index.md
+++ b/content/cumulus-linux-36/_index.md
@@ -18,51 +18,9 @@ Cumulus Linux is the first full-featured Linux operating system for the networki
 
 This user guide provides in-depth documentation on the Cumulus Linux installation process, system configuration and management, network solutions, and monitoring and troubleshooting recommendations. In addition, the quick start guide provides an end-to-end setup process to get you started.
 
-## What's New in Cumulus Linux 3.6.2
+## What's New in this Release
 
-Cumulus Linux 3.6.2 contains the following new features, platforms, and improvements:
-
-  - [Facebook Voyager](https://cumulusnetworks.com/hcl) (DWDM) (100G Tomahawk) now generally available
-  - NCLU commands available for [configuring traditional mode bridges](/cumulus-linux-36/Layer-2/Ethernet-Bridging-VLANs/Traditional-Bridge-Mode)
-  - [VRF static route leaking with EVPN](/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF/#configuring-static-route-leaking-with-evpn) symmetric routing
-  - New [`vrf_route_leak_enable` option](/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF/#enabling-vrf-route-leaking) used to enable VRF route leaking
-
-## What's New in Cumulus Linux 3.6.0
-
-Cumulus Linux 3.6.0 contains a number of new platforms, features and improvements:
-
-  - New [platforms](https://cumulusnetworks.com/hcl) include:
-      - Dell S4128T-ON (10GBASE-T Maverick)
-      - Dell S5048-ON (25G Tomahawk+)
-      - Delta AG-5648v1 (25G Tomahawk+)
-      - Edgecore AS7312-54XS (Tomahawk+)
-      - Facebook Voyager (100G Tomahawk/DWDM) Early Access
-      - Penguin Arctica 1600CS (100G Spectrum)
-      - Penguin Arctica 3200CS (100G Spectrum)
-      - Penguin Arctica 4808X (10G Spectrum)
-  - [Policy-based Routing](/cumulus-linux-36/Layer-3/Policy-based-Routing)
-  - [VRF Route Leaking](/cumulus-linux-36/Layer-3/Virtual-Routing-and-Forwarding-VRF/#vrf-route-leaking)
-  - [PTP Boundary Clock](/cumulus-linux-36/System-Configuration/Setting-Date-and-Time/#precision-time-protocol-ptp-boundary-clock)
-    on Mellanox switches
-  - [GRE Tunneling](/cumulus-linux-36/Layer-3/GRE-Tunneling) on
-    Mellanox switches
-  - New `/etc/cumulus/ports.conf` file validator finds syntax errors and
-    provides a reason for each invalid line. Error messages are shown
-    when you run the `net commit` command.
-  - Support for the combination of the `local-as` and `allowas-in`
-    commands
-  - OSPFv3 enhancements:
-      - Validated interoperability with other routers at a scale of 120
-        neighbors
-      - New NCLU commands to configure
-        [OSPFv3](/cumulus-linux-36/Layer-3/Open-Shortest-Path-First-v3-OSPFv3-Protocol/#configuring-the-ospfv3-area)
-  - EVPN Enhancements:
-      - [Type-5 routes with asymmetric routing](/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#evpn-type-5-routing-with-asymmetric-routing)
-      - [Originate default EVPN type-5 routes](/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#originating-default-evpn-type-5-routes)
-      - [Filter EVPN routes based on type](/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#filtering-evpn-routes-based-on-type)
-      - [Control which RIB routes are injected into EVPN](/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/#controlling-which-rib-routes-are-injected-into-evpn)
-
-For information on bug fixes and known issues present in this release, refer to the {{<exlink url="https://support.cumulusnetworks.com/knowledge-base/Setup-and-Getting-Started/Cumulus-Linux-3-6-Release-Notes/" text="product release notes">}}.
+For a list of the new features in this release, see {{<link url="Whats-New">}}. For bug fixes and known issues present in this release, refer to the {{<link url="Cumulus-Linux-3.6-Release-Notes" text="Cumulus Linux 3.6 Release Notes">}}.
 
 ## Open Source Contributions
 

--- a/content/knowledge-base/Configuration-and-Usage/Cables-Optics-Transceivers/No-Connectivity-with-Intel-x710-NICs-on-Firmware-6-0-x.md
+++ b/content/knowledge-base/Configuration-and-Usage/Cables-Optics-Transceivers/No-Connectivity-with-Intel-x710-NICs-on-Firmware-6-0-x.md
@@ -1,0 +1,74 @@
+---
+title: No Connectivity with Intel x710 NICs on Firmware 6.0.x
+author: Cumulus Networks
+weight: 334
+toc: 4
+---
+
+## Issue
+
+10G-SR interfaces flap when connected to Intel x710 NICs using firmware 6.0.x.
+
+Multiple customers have encountered link connectivity issues when connecting to a server containing an Intel x710 NIC with firmware 6.0.0 or 6.0.1. Intel x710 NICs are common on Dell servers. This issue can be seen on breakout ports as well.
+
+In some cases, the affected interfaces are represented as "ge" interfaces in the hardware. For example, the Broadcom ASIC shows the link as as 10G/GMII:
+
+```
+           ena/ speed/   link auto STP                 lrn inter max loop
+port      link duplex    scan neg? state  pause discard ops face  frame back
+
+ ge0(  1) down   10G FD SW   No Disable      None FA GMII 1518
+ ge1(  2) down   10G FD SW   No Disable      None FA GMII 1518
+```
+
+In other cases, the link simply remains as no carrier and can be seen flapping. This is seen upon visual inspection of the Intel x710 NIC; the corresponding link status light will flash green.
+
+## Environment
+
+Firmware:
+
+- Intel NIC x710 FW: 6.0.0 & 6.0.1
+
+Hardware (ASIC):
+
+- Broadcom Trident II
+- Broadcom Trident II+
+- Broadcom Tomahawk
+- Mellanox Spectrum
+
+Hardware (server side transceiver):
+
+- Intel AFBR.709DMZ-IN2
+
+## Workaround
+
+There are two workarounds to this issue:
+
+- Downgrade the firmware on the Intel x710 NIC to 5.x.x.
+- Using the Intel x710 6.0.x firmware, force the link speed and auto-negotiation settings on the server and on the switch.  
+      
+Apply following configuration to the 10G port on the switch:
+
+    auto swpX
+    iface swpX
+       link-speed 10000
+
+You can do this by executing the following NCLU commands:
+
+    cumulus@switch:~$ net add interface swpX link speed 10000
+    cumulus@switch:~$ net pending
+    cumulus@switch:~$ net commit
+
+The following command should be applied to the 10G ports on the server to force it to advertise 10000Mb/s:
+
+    ethtool -s ethX advertise 0x80000000000
+
+{{%notice note%}}
+
+If neither workaround is effective, contact Cumulus Support or Dell Support.
+
+{{%/notice%}}
+
+## Resolution
+
+Dell has released an updated firmware version (18.5.17) that fixes this issue. For more information, read Dell's [release notes](https://www.dell.com/support/home/us/en/04/drivers/driversdetails?driverid=t6vn9) for this version.

--- a/content/knowledge-base/Configuration-and-Usage/Cables-Optics-Transceivers/Transceiver-and-Cable-Recommendations.md
+++ b/content/knowledge-base/Configuration-and-Usage/Cables-Optics-Transceivers/Transceiver-and-Cable-Recommendations.md
@@ -1,7 +1,7 @@
 ---
 title: Transceiver and Cable Recommendations
 author: Cumulus Networks
-weight: 362
+weight: 332
 toc: 4
 ---
 

--- a/content/knowledge-base/Configuration-and-Usage/Cables-Optics-Transceivers/Transceiver-and-Cable-Self-qualification-with-Cumulus-Linux.md
+++ b/content/knowledge-base/Configuration-and-Usage/Cables-Optics-Transceivers/Transceiver-and-Cable-Self-qualification-with-Cumulus-Linux.md
@@ -1,7 +1,7 @@
 ---
 title: Transceiver and Cable Self-qualification with Cumulus Linux
 author: Cumulus Networks
-weight: 361
+weight: 331
 toc: 4
 ---
 

--- a/content/knowledge-base/Configuration-and-Usage/Cumulus-NetQ/Configure-NTP-for-On-premises-Appliances.md
+++ b/content/knowledge-base/Configuration-and-Usage/Cumulus-NetQ/Configure-NTP-for-On-premises-Appliances.md
@@ -1,0 +1,41 @@
+---
+title: Configure NTP for On-premises Appliances
+author: Cumulus Networks
+weight: 346
+toc: 4
+draft: true
+---
+
+## Issue
+
+Cumulus NetQ uses `{{<exlink url="https://chrony.tuxfamily.org/" text="chrony">}}` to synchronize time on Cumulus NetQ appliances. `chrony` syncs with NTP to keep the system clock correct in the appliance, as having the correct system clock is necessary for NetQ to function.
+
+By default, `chrony` in Cumulus NetQ is configured with public NTP pool servers. However, this does not work for air gapped on-premises environments where egress traffic to NTP pool servers on the internet is blocked. If you are using the Cumulus NetQ On-premises Appliance, you need to verify NTP points to internal NTP pool servers and not to external public servers.
+
+##  Environment
+
+- Cumulus NetQ 3.2.0 and later
+
+## Resolution
+
+To configure NTP in `chrony`:
+
+1. Edit the `chrony` configuration file:
+
+       cumulus@appliance:~$ sudo nano /etc/chrony/chrony.conf
+
+2. Change the server pool to your internal NTP servers:
+
+       \# About using servers from the NTP Pool Project in general see (LP: #104525).
+       \# Approved by Ubuntu Technical Board on 2011-02-08.
+       \# See http://www.pool.ntp.org/join.html for more information.
+       pool ntp.ubuntu.com        iburst maxsources 4
+       pool 0.ubuntu.pool.ntp.org iburst maxsources 1
+       pool 1.ubuntu.pool.ntp.org iburst maxsources 1
+       pool 2.ubuntu.pool.ntp.org iburst maxsources 2
+
+3. Save the file then restart the `chronyd` service:
+
+       cumulus@appliance:~$ sudo systemctl restart chronyd
+
+For more information about NTP, read the {{<exlink url="https://docs.cumulusnetworks.com/cumulus-linux/System-Configuration/Setting-Date-and-Time/#use-ntp" text="Cumulus Linux user guide">}}.

--- a/content/knowledge-base/Configuration-and-Usage/Cumulus-NetQ/Unsigned-Certificate-Warning-when-Connecting-to-NetQ-UI.md
+++ b/content/knowledge-base/Configuration-and-Usage/Cumulus-NetQ/Unsigned-Certificate-Warning-when-Connecting-to-NetQ-UI.md
@@ -1,0 +1,83 @@
+---
+title: Unsigned Certificate Warning when Connecting to NetQ UI
+author: Cumulus Networks
+weight: 344
+toc: 4
+draft: true
+---
+
+## Issue
+
+When I try to connect to the NetQ UI to configure my on-premises setup, I get a warning from my browser that the certificate is untrusted.
+
+## Environment
+
+- Cumulus NetQ 3.0.0 - 3.1.0
+
+## Resolution
+
+The Cumulus NetQ UI ships with a self-signed certificate, which is why your browser issues a warning. You can avoid seeing this issue by installing your own signed certificate.
+
+In order to use a custom certificate, you need the following:
+
+- A valid X509 certificate.
+- A private key file for the certificate.
+- A DNS record name configured to access the NetQ UI. The FQDN should match the common name of the certificate. If you use a wild card in the common name &mdash; for example, if the common name of the certificate is _*.example.com_ &mdash; then the NetQ telemetry server should reside on a subdomain of that domain, accessible via a URL like _netq.example.com_.
+- Cumulus NetQ must be installed and running. You can verify this by running the `netq show opta-health` command.
+
+To install a custom certificate:
+
+1. Log in to the Cumulus NetQ telemetry server via SSH and copy your certificate and key file there.
+1. Generate a Kubernetes secret called `netq-gui-ingress-tls` using following command:
+
+       cumulus@netq-ts:~$ kubectl create secret tls netq-gui-ingress-tls \
+           --namespace default \
+           --key <name of your key file>.key \
+           --cert <name of your cert file>.crt
+
+1. Verify that the secret is created:
+
+       cumulus@netq-ts:~$ kubectl get secret
+
+       NAME                               TYPE                                  DATA   AGE
+       netq-gui-ingress-tls               kubernetes.io/tls                     2      5s
+
+1. Update the ingress rule file to install self signed certificates. Create a new file called `ingress.yaml` with following content. Make sure to replace `<your hostname>` with the FQDN of the NetQ server.
+
+       apiVersion: extensions/v1beta1
+       kind: Ingress
+       metadata:
+         annotations:
+           kubernetes.io/ingress.class: "ingress-nginx"
+           nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+           nginx.ingress.kubernetes.io/ssl-redirect: "true"
+           nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+           nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
+           nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+           nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+           nginx.ingress.kubernetes.io/proxy-body-size: 10g
+           nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+         name: netq-gui-ingress-external
+         namespace: default
+       spec:
+         rules:
+         - host: <your hostname>
+           http:
+             paths:
+             - backend:
+                 serviceName: netq-gui
+                 servicePort: 80
+         tls:
+         - hosts:
+           - <your hostname>
+           secretName: netq-gui-ingress-tls
+
+1. Run the following command:
+
+       cumulus@netq-ts:~$ kubectl apply -f ingress.yaml
+
+   If your ingress rule is successfully configured, a message like the following appears:
+
+       ingress.extensions/netq-gui-ingress-external configured
+
+Your custom certificate should now be working. Verify it in the UI by visiting `https://<your hostname>` in your browser.


### PR DESCRIPTION
Ticket: UD-2193

Moved 3.6 release notes under the 3.6 docs, like we do for all other products now. Created a What's New page for 3.6.
Some more articles to migrate, and other cleanup with page weights.