### PR TITLE
Update EVPN-PIM.md

### DIFF
--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-PIM.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-PIM.md
@@ -16,7 +16,7 @@ For PIM-SM, type-3 routes do not result in any forwarding entries. Cumulus Linux
 
 {{%notice note%}}
 
-EVPN-PIM is supported on Broadcom Trident3 and Trident 2+ switches, and Mellanox Spectrum and Spectrum-2 switches.
+EVPN-PIM is supported on Broadcom Trident3 and Trident 2+ switches, and Mellanox Spectrum, Spectrum-2 and Spectrum-3 switches.
 
 {{%/notice%}}
 


### PR DESCRIPTION
EVPN PIM Is supported on Spectrum 3 as well. This is already mentioned in EVPN Multi-homing document which uses PIM EVPN. To avoid any confusion, it'd be good to update in PIM EVPN document as well.