### PR TITLE
EVPN-MH now GA and updated

### DIFF
--- a/content/cumulus-linux-36/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
+++ b/content/cumulus-linux-36/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
@@ -800,13 +800,13 @@ with the number of applications available.
 <tr class="odd">
 <td><p>BGP peer failure</p></td>
 <td><pre><code>cumulus@switch:~$ vtysh -c &quot;show ip bgp summary json&quot;
-cumulus@switch:~$ cl-bgp summary show json</code></pre></td>
+cumulus@switch:~$ net show bgp summary json</code></pre></td>
 <td><p>60 seconds</p></td>
 </tr>
 <tr class="even">
 <td><p>BGP route table</p></td>
 <td><pre><code>cumulus@switch:~$ vtysh -c &quot;show ip bgp json&quot;
-cumulus@switch:~$ cl-bgp route show</code></pre></td>
+cumulus@switch:~$ net show route bgp json</code></pre></td>
 <td><p>600 seconds</p></td>
 </tr>
 </tbody>

--- a/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
+++ b/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
@@ -794,13 +794,13 @@ with the number of applications available.
 <tr class="odd">
 <td><p>BGP peer failure</p></td>
 <td><pre><code>cumulus@switch:~$ vtysh -c &quot;show ip bgp summary json&quot;
-cumulus@switch:~$ cl-bgp summary show json</code></pre></td>
+cumulus@switch:~$ net show bgp summary json</code></pre></td>
 <td><p>60 seconds</p></td>
 </tr>
 <tr class="even">
 <td><p>BGP route table</p></td>
 <td><pre><code>cumulus@switch:~$ vtysh -c &quot;show ip bgp json&quot;
-cumulus@switch:~$ cl-bgp route show</code></pre></td>
+cumulus@switch:~$ net show route bgp json</code></pre></td>
 <td><p>600 seconds</p></td>
 </tr>
 </tbody>

--- a/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
+++ b/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
@@ -186,8 +186,8 @@ Monitoring the routing table provides trending on the size of the infrastructure
 
 | BGP Element | Monitoring Commands | Interval Poll |
 |------------ |-------------------- |-------------- |
-| BGP peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ cl-bgp summary show json</pre> | 60 seconds |
-| BGP route table | <pre>cumulus@switch:~$ vtysh -c "show ip bgp json"<br>cumulus@switch:~$ cl-bgp route show</pre> | 600 seconds |
+| BGP peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ net show bgp summary json</pre> | 60 seconds |
+| BGP route table | <pre>cumulus@switch:~$ vtysh -c "show ip bgp json"<br>cumulus@switch:~$ net show route bgp json</pre> | 600 seconds |
 
 | BGP Logs | Log Location | Log Entries |
 |--------- |------------- |------------ |

--- a/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
+++ b/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
@@ -186,8 +186,8 @@ Monitoring the routing table provides trending on the size of the infrastructure
 
 | BGP Element | Monitoring Commands | Interval Poll |
 |------------ |-------------------- |-------------- |
-| BGP peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ cl-bgp summary show json</pre> | 60 seconds |
-| BGP route table | <pre>cumulus@switch:~$ vtysh -c "show ip bgp json"<br>cumulus@switch:~$ cl-bgp route show</pre> | 600 seconds |
+| BGP peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ net show bgp summary json</pre> | 60 seconds |
+| BGP route table | <pre>cumulus@switch:~$ vtysh -c "show ip bgp json"<br>cumulus@switch:~$ net show route bgp json</pre> | 600 seconds |
 
 | BGP Logs | Log Location | Log Entries |
 |--------- |------------- |------------ |

--- a/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
+++ b/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
@@ -185,8 +185,8 @@ Monitoring the routing table provides trending on the size of the infrastructure
 
 | BGP Element | Monitoring Commands | Interval Poll |
 |------------ |-------------------- |-------------- |
-| BGP peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ cl-bgp summary show json</pre> | 60 seconds |
-| BGP route table | <pre>cumulus@switch:~$ vtysh -c "show ip bgp json"<br>cumulus@switch:~$ cl-bgp route show</pre> | 600 seconds |
+| BGP peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ net show bgp summary json</pre> | 60 seconds |
+| BGP route table | <pre>cumulus@switch:~$ vtysh -c "show ip bgp json"<br>cumulus@switch:~$ net show route bgp json</pre> | 600 seconds |
 
 | BGP Logs | Log Location | Log Entries |
 |--------- |------------- |------------ |

--- a/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
+++ b/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Monitoring-Best-Practices.md
@@ -185,8 +185,8 @@ Monitoring the routing table provides trending on the size of the infrastructure
 
 | BGP Element | Monitoring Commands | Interval Poll |
 |------------ |-------------------- |-------------- |
-| BGP peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ net show bgp summary json</pre> | 60 seconds |
-| BGP route table | <pre>cumulus@switch:~$ vtysh -c "show ip bgp json"<br>cumulus@switch:~$ net show route bgp json</pre> | 600 seconds |
+| BGP peer failure | <pre>cumulus@switch:~$ sudo vtysh -c "show ip bgp summary json"<br>cumulus@switch:~$ net show bgp summary json</pre> | 60 seconds |
+| BGP route table | <pre>cumulus@switch:~$ sudo vtysh -c "show ip bgp json"<br>cumulus@switch:~$ net show route bgp json</pre> | 600 seconds |
 
 | BGP Logs | Log Location | Log Entries |
 |--------- |------------- |------------ |
@@ -200,8 +200,8 @@ Monitoring the routing table provides trending on the size of the infrastructure
 
 | OSPF Element |Monitoring Commands |Interval Poll |
 |------------- |------------------- |------------- |
-|OSPF protocol peer failure | <pre>cumulus@switch:~$ vtysh -c "show ip ospf neighbor all json"<br>cumulus@switch:~$ cl-ospf summary show json</pre>|60 seconds |
-| OSPF link state database | <pre>cumulus@switch:~$ vtysh - c "show ip ospf database"</pre> | 600 seconds |
+|OSPF protocol peer failure | <pre>cumulus@switch:~$ sudo vtysh -c "show ip ospf neighbor all json"<br>cumulus@switch:~$ cl-ospf summary show json</pre>|60 seconds |
+| OSPF link state database | <pre>cumulus@switch:~$ sudo vtysh - c "show ip ospf database"</pre> | 600 seconds |
 
 ### Route and Host Entries
 

--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -459,7 +459,7 @@ cumulus@switch:~$ sudo systemctl restart switchd.service
 
 Some third party switch vendors don't advertise EAD-per-EVI routes; they only advertise EAD-per-ES routes. To interoperate with these vendors, you need to disable EAD-per-EVI route advertisements.
 
-To remove the dependency on EAD-per-EVI routes and activate the PE upon receiving the EAD-per-ES route, run:
+To remove the dependency on EAD-per-EVI routes and activate the VTEP upon receiving the EAD-per-ES route, run:
 
     cumulus@switch:~$ net add bgp l2vpn evpn disable-ead-evi-rx
     cumulus@switch:~$ net commit

--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -431,9 +431,11 @@ Fast failover is also triggered by:
 - Rebooting a leaf switch or VTEP.
 - Uplink failure. When all uplinks are down, the Ethernet segment bonds on the switch are protodowned or error disabled.
 
-### Disable Next Hop Groups
+### Disable Next Hop Group Sharing in the ASIC
 
 Container sharing for both layer 2 and layer 3 next hop groups is enabled by default when EVPN-MH is configured. These settings are stored in the `evpn.multihoming.shared_l2_groups` and `evpn.multihoming.shared_l3_groups` variables.
+
+Disabling container sharing allows for faster failover when an Ethernet segment link flaps.
 
 To disable either setting, edit `switchd.conf`, set the variable to _FALSE_, then restart the `switchd` service. For example, to disable container sharing for layer 3 next hop groups, do the following:
 
@@ -447,6 +449,25 @@ evpn.multihoming.shared_l3_groups = FALSE
 
 cumulus@switch:~$ sudo systemctl restart switchd.service
 ```
+
+### Disable EAD-per-EVI Route Advertisements
+
+{{<exlink url="https://tools.ietf.org/html/rfc7432" text="RFC 7432">}} requires type-1/EAD (Ethernet Auto-discovery) routes to be advertised two ways:
+
+- As EAD-per-ES (Ethernet Auto-discovery per Ethernet segment) routes
+- As EAD-per-EVI (Ethernet Auto-discovery per EVPN instance) routes
+
+Some third party switch vendors don't advertise EAD-per-EVI routes; they only advertise EAD-per-ES routes. To interoperate with these vendors, you need to disable EAD-per-EVI route advertisements.
+
+To remove the dependency on EAD-per-EVI routes and activate the PE upon receiving the EAD-per-ES route, run:
+
+    cumulus@switch:~$ net add bgp l2vpn evpn disable-ead-evi-rx
+    cumulus@switch:~$ net commit
+
+To suppress the advertisement of EAD-per-EVI routes, run:
+
+    cumulus@switch:~$ net add bgp l2vpn evpn disable-ead-evi-tx
+    cumulus@switch:~$ net commit
 
 ## Troubleshooting
 

--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -5,12 +5,6 @@ weight: 555
 toc: 4
 ---
 
-{{%notice warning%}}
-
-EVPN multihoming is an {{<exlink url="https://docs.cumulusnetworks.com/knowledge-base/Support/Support-Offerings/Early-Access-Features-Defined/" text="early access feature">}}.
-
-{{%/notice%}}
-
 *EVPN multihoming* (EVPN-MH) provides support for active-active server redundancy. It is a standards-based replacement for MLAG in data centers deploying Clos topologies. Replacing MLAG:
 
 - Eliminates the need for peerlinks or inter-switch links between the top of rack switches

--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -16,7 +16,7 @@ EVPN-MH uses BGP-EVPN type-1, type-2 and type-4 routes for discovering Ethernet 
 
 Configuring EVPN-MH involves setting an Ethernet segment system MAC address (`es-sys-mac`) and a local Ethernet segment ID (`local-es-id`) on a static or LACP bond. The `es-sys-mac` and `local-es-id` are used to build a type-3 `es-id`. This `es-id` must be globally unique across all the EVPN VTEPs. The same `es-sys-mac` can be configured on multiple interfaces.
 
-{{%notice note%}}
+{{%notice info%}}
 
 When using Spectrum 2 or Spectrum 3 switches, an Ethernet segment can span more than two switches. Each Ethernet segment is a distinct redundancy group.
 
@@ -46,7 +46,7 @@ In order to use EVPN-MH, you must remove any MLAG configuration on the switch. T
 
 ## Configure EVPN-MH
 
-To configure EVPN-MH, first you need to enable the `evpn.multihoming.enable` variable in `switchd`. Then you need to specify the following required settings:
+To configure EVPN-MH, first you need to enable the `evpn.multihoming.enable` variable in `switchd.conf`. Then you need to specify the following required settings:
 
 - The Ethernet segment ID (`es-id`)
 - The Ethernet segment system MAC address (`es-sys-mac`)

--- a/content/knowledge-base/Security/Security-Issues-and-Announcements/Adding-MD5-enabled-BGP-Neighbors.md
+++ b/content/knowledge-base/Security/Security-Issues-and-Announcements/Adding-MD5-enabled-BGP-Neighbors.md
@@ -102,9 +102,9 @@ This will tear down any other layer 3 sessions and affect network traffic!
 
 {{%/notice%}}
 
-8.  Confirm this worked using `cl-bgp summary`:  
+8.  Confirm this worked using `net show bgp summary`:  
 
-        cumulus@switch:~$ sudo cl-bgp summary 
+        cumulus@switch:~$ net show bgp summary 
         BGP router identifier 192.0.2.2, local AS number 65001
         RIB entries 0, using 0 bytes of memory
         Peers 1, using 6652 bytes of memory
@@ -142,7 +142,7 @@ This will tear down any other layer 3 sessions and affect network traffic!
 
 {{%/notice%}}
 
-14. Confirm this worked using `cl-bgp summary`:  
+14. Confirm this worked using `net show bgp summary`:  
 
         BGP router identifier 192.0.2.5, local AS number 65000
         RIB entries 0, using 0 bytes of memory


### PR DESCRIPTION
UD-2215, UD-2220

Removed EA notice. Added sections on disabling EAD-per-EVI and next hop group sharing.

Also cleaned up some old cl-bgp references in lieu of NCLU.