### PR TITLE
EVPN-MH requires PIM for BUM traffic

### DIFF
--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -28,6 +28,13 @@ However, when using Spectrum A1 switches, a maximum of two switches can particip
 
 - Known unicast traffic multihoming via type-1/EAD (Ethernet auto discovery) routes and type-2 (non-zero ESI) routes. Includes active-active redundancy via aliasing and support for fast failover.
 - EVPN BUM traffic handling with {{<link title="EVPN BUM Traffic with PIM-SM" text="EVPN-PIM">}} on multihomed sites via Type-4/ESR routes, which includes split-horizon-filtering and designated forwarder election.
+
+  {{%notice warning%}}
+
+Head-end replication is not supported with multihoming, so you must use EVPN-PIM for BUM traffic handling.
+
+{{%/notice%}}
+
 - {{<link url="VLAN-aware-Bridge-Mode" text="VLAN-aware bridge mode">}} only.
 - {{<link url="Inter-subnet-Routing/#symmetric-routing" text="Distributed symmetric routing">}}.
 - {{<link url="Basic-Configuration/#arp-and-nd-suppression" text="ARP suppression">}} must be enabled.


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Make explicit that you must use EVPN-PIM with multihoming.