### PR TITLE
Remove unnecessary limitation for FRR from BGP doc

### DIFF
--- a/content/cumulus-linux-37/Layer-3/Border-Gateway-Protocol-BGP.md
+++ b/content/cumulus-linux-37/Layer-3/Border-Gateway-Protocol-BGP.md
@@ -358,7 +358,6 @@ The above rules imply that there are scenarios where a generated update has two 
 
 ### Limitations
 
-- Interface-based peering with separate IPv4 and IPv6 sessions is not supported.
 - In Cumulus Linux 3.7.1 and earlier, ENHE is sent for IPv6 link-local peerings only. In Cumulus Linux 3.7.2 and later, ENHE can also be also sent for IPv6 GUA peerings (see below).
 - BGP unnumbered only works with two switches at a time, as it is meant to work with PTP (point-to-point protocol).
 - If an IPv4 /30 or /31 IP address is assigned to the interface, IPv4 peering is used over IPv6 link-local peering.


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

No need to mention separation of v4 and v6 sessions.