### PR TITLE
Update Hybrid-Cloud-Connectivity-with-QinQ-and-VXLANs.md

### DIFF
--- a/content/cumulus-linux-42/Network-Virtualization/Hybrid-Cloud-Connectivity-with-QinQ-and-VXLANs.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Hybrid-Cloud-Connectivity-with-QinQ-and-VXLANs.md
@@ -16,7 +16,7 @@ In Cumulus Linux, you map QinQ packets to VXLANs through:
 QinQ is available on switches with the following ASICs:
 
 - Broadcom Tomahawk 2, Tomahawk+, Tomahawk, Trident3, Trident II+ and Trident II.
-- Mellanox Spectrum, only with {{<link url="VLAN-aware-Bridge-Mode" text="VLAN-aware bridges">}} with 802.1ad and only with single tag translation.
+- Mellanox Spectrum ASICs, only with {{<link url="VLAN-aware-Bridge-Mode" text="VLAN-aware bridges">}} with 802.1ad and only with single tag translation.
 
 ## Configure Single Tag Translation
 


### PR DESCRIPTION
Changed "Mellanox Spectrum" to "Mellanox Spectrum ASICs" to make it more clear that QinQ is supported on Spectrum2