### PR TITLE
Update VXLAN-Tunnel-DSCP.md

### DIFF
--- a/content/cumulus-linux-42/Network-Virtualization/VXLAN-Tunnel-DSCP.md
+++ b/content/cumulus-linux-42/Network-Virtualization/VXLAN-Tunnel-DSCP.md
@@ -22,7 +22,7 @@ You can set the following DSCP operations by editing the `/etc/cumulus/switchd.c
 | ------ | ----------- |
 |`vxlan.def_encap_dscp_action`| Sets the VXLAN outer DSCP action during encapsulation. You can specify one of the following options:<br>- `copy` (if the inner packet is IP)<br>- `set` (to a specific value)<br>- `derive` (from the switch priority).<br>The default setting is `derive`. |
 | `vxlan.def_encap_dscp_value`| If the `vxlan.def_encap_dscp_action` option is `set`, you must specify a value. |
-| `xlan.def_decap_dscp_action` | Sets the VXLAN decapsulation DSCP/COS action. You can specify one of the following options:<br>- `copy` (if the inner packet is IP)<br>- `preserve` (the inner DSCP is unchanged)<br>- `derive` (from the switch priority) |
+| `vxlan.def_decap_dscp_action` | Sets the VXLAN decapsulation DSCP/COS action. You can specify one of the following options:<br>- `copy` (if the inner packet is IP)<br>- `preserve` (the inner DSCP is unchanged)<br>- `derive` (from the switch priority) |
 
 After you modify `/etc/cumulus/switchd.conf` file, you must restart `switchd` for the changes to take effect.
 


### PR DESCRIPTION
There was a typo for "vxlan.def_decap_dscp_action". Instead, it was present as "xlan.def_decap_dscp_action".