### PR TITLE
Update Management-VRF.md

### DIFF
--- a/content/cumulus-linux-42/Layer-3/Management-VRF.md
+++ b/content/cumulus-linux-42/Layer-3/Management-VRF.md
@@ -165,7 +165,7 @@ cumulus@switch:~$ ping -I mgmt <destination-ip>
 Or:
 
 ```
-cumulus@switch:~$ traceroute -s <source-ip> <destination-ip>
+cumulus@switch:~$ sudo traceroute -i mgmt -s <source-ip> <destination-ip>
 ```
 
 For additional information on using `ping` and `traceroute`, see {{<link url="Network-Troubleshooting">}}.


### PR DESCRIPTION
The previously proposed traceroute command options, do not meet the criteria for execution in the the management VRF.

'sudo' required due to portential error:
setsockopt SO_BINDTODEVICE: Operation not permitted

