### PR TITLE
Fixed /etc/apt/sources.list examples to show 3.2

### DIFF
--- a/content/cumulus-netq-32/Manage-Deployment/Install-NetQ/Install-NetQ-Device-SW/Install-NetQ-Agent-CLI/Install-NetQ-Agents-CLI-on-CL.md
+++ b/content/cumulus-netq-32/Manage-Deployment/Install-NetQ/Install-NetQ-Device-SW/Install-NetQ-Agent-CLI/Install-NetQ-Agents-CLI-on-CL.md
@@ -63,7 +63,7 @@ Edit the `/etc/apt/sources.list` file to add the repository for Cumulus NetQ.
 ```
 cumulus@switch:~$ sudo nano /etc/apt/sources.list
 ...
-deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 netq-3.0
+deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 netq-3.2
 ...
 ```
 
@@ -80,7 +80,7 @@ Add the repository:
 ```
 cumulus@switch:~$ sudo nano /etc/apt/sources.list
 ...
-deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-4 netq-3.0
+deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-4 netq-3.2
 ...
 ```
 


### PR DESCRIPTION
Previously the /etc/apt/sources.list examples showed how to install netq-3.0 onto the agents instead of netq-3.2. Fixed this line so that users just have to copy and paste the correct line.