### PR TITLE
Fix hostapd configuration parameter for maximum number of stations

### DIFF
--- a/content/cumulus-linux-40/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
+++ b/content/cumulus-linux-40/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
@@ -837,7 +837,7 @@ cumulus@switch:~$ net commit
 
 {{< tab "Linux Commands" >}}
 
-Edit the `/etc/hostapd.conf` file to add the `max_number_stations=` option. For example:
+Edit the `/etc/hostapd.conf` file to add the `max_num_sta=` option. For example:
 
 ```
 cumulus@switch:~$ sudo nano /etc/hostapd.conf
@@ -845,7 +845,7 @@ eap_server=0
 ieee8021x=1
 driver=wired
 dynamic_vlan=1
-max_number_stations=10
+max_num_sta=10
 interfaces=swp1,swp2,swp3,swp4
 mab_interfaces=
 parking_vlan_interfaces=swp1

--- a/content/cumulus-linux-41/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
+++ b/content/cumulus-linux-41/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
@@ -1183,7 +1183,7 @@ cumulus@switch:~$ net commit
 
 {{< tab "Linux Commands ">}}
 
-Edit the `/etc/hostapd.conf` file to add the `max_number_stations=` option. For example:
+Edit the `/etc/hostapd.conf` file to add the `max_num_sta=` option. For example:
 
 ```
 cumulus@switch:~$ sudo nano /etc/hostapd.conf
@@ -1191,7 +1191,7 @@ eap_server=0
 ieee8021x=1
 driver=wired
 dynamic_vlan=1
-max_number_stations=10
+max_num_sta=10
 interfaces=swp1,swp2,swp3,swp4
 mab_interfaces=
 parking_vlan_interfaces=swp1

--- a/content/cumulus-linux-42/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
+++ b/content/cumulus-linux-42/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
@@ -1183,7 +1183,7 @@ cumulus@switch:~$ net commit
 
 {{< tab "Linux Commands ">}}
 
-Edit the `/etc/hostapd.conf` file to add the `max_number_stations=` option. For example:
+Edit the `/etc/hostapd.conf` file to add the `max_num_sta=` option. For example:
 
 ```
 cumulus@switch:~$ sudo nano /etc/hostapd.conf
@@ -1191,7 +1191,7 @@ eap_server=0
 ieee8021x=1
 driver=wired
 dynamic_vlan=1
-max_number_stations=10
+max_num_sta=10
 interfaces=swp1,swp2,swp3,swp4
 mab_interfaces=
 parking_vlan_interfaces=swp1

--- a/content/cumulus-linux-43/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
+++ b/content/cumulus-linux-43/Layer-1-and-Switch-Ports/802.1X-Interfaces.md
@@ -1183,7 +1183,7 @@ cumulus@switch:~$ net commit
 
 {{< tab "Linux Commands ">}}
 
-Edit the `/etc/hostapd.conf` file to add the `max_number_stations=` option. For example:
+Edit the `/etc/hostapd.conf` file to add the `max_num_sta=` option. For example:
 
 ```
 cumulus@switch:~$ sudo nano /etc/hostapd.conf
@@ -1191,7 +1191,7 @@ eap_server=0
 ieee8021x=1
 driver=wired
 dynamic_vlan=1
-max_number_stations=10
+max_num_sta=10
 interfaces=swp1,swp2,swp3,swp4
 mab_interfaces=
 parking_vlan_interfaces=swp1


### PR DESCRIPTION
Configuration parameter for maximum number of stations is max_num_sta. NCLU commend set the configuration correctly, but documentation for Linux commands is wrong.