### PR TITLE
EVPN-MH supported with LACP bypass

### DIFF
--- a/content/cumulus-linux-42/Layer-2/LACP-Bypass.md
+++ b/content/cumulus-linux-42/Layer-2/LACP-Bypass.md
@@ -15,6 +15,7 @@ In *all-active* mode, when a bond has multiple slave interfaces, each bond slave
 - All-active mode is *not* supported on bonds that are *not* specified as bridge ports on the switch.
 - STP does not run on the individual bond slave interfaces when the LACP bond is in all-active mode. Only use all-active mode on host-facing LACP bonds. Configuring {{<link url="Spanning-Tree-and-Rapid-Spanning-Tree-STP" text="STP BPDU guard">}} together with all-active mode is highly recommended.
 - In an {{<link url="Multi-Chassis-Link-Aggregation-MLAG" text="MLAG deployment">}} where bond slaves of a host are connected to two switches and the bond is in all-active mode, all the slaves of bond are active on both the primary and secondary MLAG nodes.
+- LACP bypass is supported with {{<link url="EVPN-Multihoming/#supported-features" text="EVPN multihoming">}}.
 - `priority mode`, `bond-lacp-bypass-period`, `bond-lacp-bypass-priority`, and `bond-lacp-bypass-all-active` are not supported.
 
 {{%/notice%}}

--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -38,6 +38,9 @@ Head-end replication is not supported with multihoming, so you must use {{<link 
 {{%/notice%}}
 
 - {{<link url="VLAN-aware-Bridge-Mode" text="VLAN-aware bridge mode">}} only.
+- {{<link url="LACP-Bypass">}} is supported.
+  - When an EVPN-MH bond enters LACP bypass state, BGP stops advertising EVPN type-1 and type-4 routes for that bond. Split-horizon and designated forwarder filters are disabled.
+  - When an EVPN-MH bond exits the LACP bypass state, BGP starts advertising EVPN type-1 and type-4 routes for that bond. Split-horizon and designated forwarder filters are enabled.
 - {{<link url="Inter-subnet-Routing/#symmetric-routing" text="Distributed symmetric routing">}}.
 - {{<link url="Basic-Configuration/#arp-and-nd-suppression" text="ARP suppression">}} must be enabled.
 - EVI (*EVPN virtual instance*). Cumulus Linux supports VLAN-based service only, so the EVI is just a layer 2 VNI.

--- a/content/cumulus-linux-43/Layer-2/LACP-Bypass.md
+++ b/content/cumulus-linux-43/Layer-2/LACP-Bypass.md
@@ -15,6 +15,7 @@ In *all-active* mode, when a bond has multiple slave interfaces, each bond slave
 - All-active mode is *not* supported on bonds that are *not* specified as bridge ports on the switch.
 - STP does not run on the individual bond slave interfaces when the LACP bond is in all-active mode. Only use all-active mode on host-facing LACP bonds. Configure {{<link url="Spanning-Tree-and-Rapid-Spanning-Tree-STP" text="STP BPDU guard">}} together with all-active mode.
 - In an {{<link url="Multi-Chassis-Link-Aggregation-MLAG" text="MLAG deployment">}} where bond slaves of a host are connected to two switches and the bond is in all-active mode, all the slaves of bond are active on both the primary and secondary MLAG nodes.
+- LACP bypass is supported with {{<link url="EVPN-Multihoming/#supported-features" text="EVPN multihoming">}}.
 - `priority mode`, `bond-lacp-bypass-period`, `bond-lacp-bypass-priority`, and `bond-lacp-bypass-all-active` are not supported.
 
 {{%/notice%}}

--- a/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -38,6 +38,9 @@ Head-end replication is not supported with multihoming, so you must use {{<link 
 {{%/notice%}}
 
 - {{<link url="VLAN-aware-Bridge-Mode" text="VLAN-aware bridge mode">}} only.
+- {{<link url="LACP-Bypass">}} is supported.
+  - When an EVPN-MH bond enters LACP bypass state, BGP stops advertising EVPN type-1 and type-4 routes for that bond. Split-horizon and designated forwarder filters are disabled.
+  - When an EVPN-MH bond exits the LACP bypass state, BGP starts advertising EVPN type-1 and type-4 routes for that bond. Split-horizon and designated forwarder filters are enabled.
 - {{<link url="Inter-subnet-Routing/#symmetric-routing" text="Distributed symmetric routing">}}.
 - {{<link url="Basic-Configuration/#arp-and-nd-suppression" text="ARP suppression">}} must be enabled.
 - EVI (*EVPN virtual instance*). Cumulus Linux supports VLAN-based service only, so the EVI is just a layer 2 VNI.


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Describe how LACP bypass interoperates with EVPN multihoming.