### PR TITLE
Move L1 guide to a better place and link to it from the ethtool topic

### DIFF
--- a/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Troubleshooting-Network-Interfaces/Monitoring-Interfaces-and-Transceivers-Using-ethtool.md
+++ b/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Troubleshooting-Network-Interfaces/Monitoring-Interfaces-and-Transceivers-Using-ethtool.md
@@ -4,7 +4,14 @@ author: NVIDIA
 weight: 1100
 toc: 4
 ---
+
 The `ethtool` command enables you to query or control the network driver and hardware settings. It takes the device name (like swp1) as an argument. When the device name is the only argument to `ethtool`, it prints the current settings of the network device. See `man ethtool(8)` for details. Not all options are currently supported on switch port interfaces.
+
+{{%notice tip%}}
+
+The `l1-show` command is the preferred tool for monitoring Ethernet data. See the {{<link url="Troubleshoot-Layer-1">}} guide for details.
+
+{{%/notice%}}
 
 ## Monitor Interface Status Using ethtool
 

--- a/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Troubleshooting-Network-Interfaces/Troubleshoot-Layer-1.md
+++ b/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Troubleshooting-Network-Interfaces/Troubleshoot-Layer-1.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot Layer 1
 author: NVIDIA
-weight: 1025
+weight: 1095
 toc: 3
 ---
 


### PR DESCRIPTION
Ticket: UD-1545
Reviewed By:
Testing Done:

The L1 troubleshooting guide works better under network interfaces. Also call out the tool from the ethtool chapter, noting is the preferred way to monitor.