### PR TITLE
NetQ 2.1.2 PDFs, remove Chassis link, tech guide updates

### DIFF
--- a/content/cumulus-linux-36/Network-Solutions/Data-Center-Host-to-ToR-Architecture.md
+++ b/content/cumulus-linux-36/Network-Solutions/Data-Center-Host-to-ToR-Architecture.md
@@ -36,15 +36,15 @@ iface bridge
   bridge-ports swp1 peerlink
   bridge-vids 1-2000
   bridge-stp on
- 
+
 auto bridge.10
 iface bridge.10
   address 10.1.10.2/24
- 
+
 auto peerlink
 iface peerlink
     bond-slaves glob swp49-50
- 
+
 auto swp1
 iface swp1
   mstpctl-portadminedge yes
@@ -52,20 +52,20 @@ iface swp1
 <p><strong>Example Host Config (Ubuntu)</strong></p>
 <pre><code>auto eth1
 iface eth1 inet manual
- 
+
 auto eth1.10
 iface eth1.10 inet manual
- 
+
 auto eth2
 iface eth1 inet manual
- 
+
 auto eth2.20
 iface eth2.20 inet manual
- 
+
 auto br-10
 iface br-10 inet manual
   bridge-ports eth1.10 vnet0
- 
+
 auto br-20
 iface br-20 inet manual
   bridge-ports eth2.20 vnet1</code></pre></td>
@@ -156,23 +156,23 @@ iface bridge
   bridge-ports host-01 peerlink
   bridge-vids 1-2000
   bridge-stp on
- 
+
 auto bridge.10
 iface bridge.10
   address 172.16.1.2/24
   address-virtual 44:38:39:00:00:10 172.16.1.1/24
- 
+
 auto peerlink
 iface peerlink
     bond-slaves glob swp49-50
- 
+
 auto peerlink.4094
 iface peerlink.4094
     address 169.254.1.2
     clagd-enable yes
     clagd-peer-ip 169.254.1.2
     clagd-system-mac 44:38:39:FF:40:94
- 
+
 auto host-01
 iface host-01
   bond-slaves swp1
@@ -183,10 +183,10 @@ iface host-01
 iface bond0 inet manual
   bond-slaves eth0 eth1
   {bond-defaults removed for brevity}
- 
+
 auto bond0.10
 iface bond0.10 inet manual
- 
+
 auto vm-br10
 iface vm-br10 inet manual
   bridge-ports bond0.10 vnet0</code></pre></td>
@@ -318,7 +318,7 @@ iface eth1 inet static
 <li><p>No redundancy, uses single ToR as gateway.</p></li>
 </ul></td>
 <td><ul>
-<li><p><!-- <a href="https://cumulusnetworks.com/media/cumulus/pdf/technical/validated-design-guides/Big-Data-Cumulus-Linux-Validated-Design-Guide.pdf" class="external-link">Big Data validated design guide</a> uses single attached ToR --></p></li>
+<li><p><a href="https://cumulusnetworks.com/learn/resources/guides/big-data-cumulus-linux-installation-guide-2" class="external-link">Big Data validated design guide</a> uses single attached ToR</p></li>
 </ul></td>
 </tr>
 </tbody>

--- a/content/cumulus-linux-37/Network-Solutions/Data-Center-Host-to-ToR-Architecture.md
+++ b/content/cumulus-linux-37/Network-Solutions/Data-Center-Host-to-ToR-Architecture.md
@@ -321,7 +321,7 @@ iface eth1 inet static
 <li><p>No redundancy, uses single ToR as gateway.</p></li>
 </ul></td>
 <td><ul>
-<li><p><!-- {{<exlink url="https://cumulusnetworks.com/media/cumulus/pdf/technical/validated-design-guides/Big-Data-Cumulus-Linux-Validated-Design-Guide.pdf" text="Big Data validated design guide">}} uses single attached ToR --></p></li>
+<li><p>{{<exlink url="https://cumulusnetworks.com/learn/resources/guides/big-data-cumulus-linux-installation-guide-2" text="Big Data validated design guide">}} uses single attached ToR</p></li>
 </ul></td>
 </tr>
 </tbody>

--- a/content/knowledge-base/Setup-and-Getting-Started/Beginners-Guide-to-Getting-Started-with-Cumulus-Linux.md
+++ b/content/knowledge-base/Setup-and-Getting-Started/Beginners-Guide-to-Getting-Started-with-Cumulus-Linux.md
@@ -95,6 +95,6 @@ Learn how to use the nano text editor ([cheat sheet --- external link](http://ww
 
 ### Cumulus Networks Validated Design Guides
 
-<!-- - [Big Data Validated Design](https://cumulusnetworks.com/media/cumulus/pdf/technical/validated-design-guides/Big-Data-Cumulus-Linux-Validated-Design-Guide.pdf) -->
+- [Big Data Validated Design](https://cumulusnetworks.com/learn/resources/guides/big-data-cumulus-linux-installation-guide-2)
 - [OpenStack Validated Design](https://cumulusnetworks.com/learn/resources/guides/openstack-and-cumulus-linux-installation-guide-2)
 - [VMware VSphere Validated Design](https://cumulusnetworks.com/learn/resources/guides/vmware-vsphere-cumulus-linux-installation-guide-2)

--- a/content/pdfs/_index.md
+++ b/content/pdfs/_index.md
@@ -52,9 +52,9 @@ If you are running a version of Cumulus Linux earlier than 3.6 or Cumulus NetQ e
 | 2.2 CLI Guide                                      | {{<exlink url="https://drive.google.com/file/d/18eBtJknj2Oh1w9xHGGGTFpHYMLGkl8En/view?usp=sharing" text="2.2 CLI Guide PDF" >}}          |
 | 2.2 Deployment Guide                               | {{<exlink url="https://drive.google.com/file/d/11t3u9XNzd68BufVf0H-Y_MU9lupUGUgH/view?usp=sharing" text="2.2 Deployment Guide PDF" >}}   |
 | 2.2 UI User Guide                                  | {{<exlink url="https://drive.google.com/file/d/16bSLPF7LND2svvEX0bqGzYc8guJd_UII/view?usp=sharing" text="2.2 UI Guide PDF" >}}           |
-| 2.1.2 CLI User Guide                               | {{<exlink url="https://drive.google.com/file/d/1StA5Hr33uC3DcsmWVU2QinPDmE7yeg8Y/view?usp=sharing" text="2.1.2 CLI Guide PDF" >}}        |
-| 2.1.2 Deployment Guide                             | {{<exlink url="https://drive.google.com/file/d/1GR2deyIg0W7RRa2t76k6NUr4PtU0hYkJ/view?usp=sharing" text="2.1.2 Deployment Guide PDF" >}} |
-| 2.1.2 UI User Guide                                | {{<exlink url="https://drive.google.com/file/d/11Zbs1xMk-b6ZtagNrg5pW57s6EkRh6lL/view?usp=sharing" text="2.1.2 User Interface Guide PDF" >}}         |
+| 2.1.2 CLI User Guide                               | {{<exlink url="https://drive.google.com/file/d/1kBEKyVH9pIoIKrqtjMYh8yOdZBHWy1fE/view?usp=sharing" text="2.1.2 CLI Guide PDF" >}}        |
+| 2.1.2 Deployment Guide                             | {{<exlink url="https://drive.google.com/file/d/1d-2kZGNynGzvPYBERxejFwzzkDQQWv6q/view?usp=sharing" text="2.1.2 Deployment Guide PDF" >}} |
+| 2.1.2 UI User Guide                                | {{<exlink url="https://drive.google.com/file/d/1rxW6Jiwh_tAVt4TnrAQWhTDwAHDB2Pjf/view?usp=sharing" text="2.1.2 User Interface Guide PDF" >}}         |
 | 1.4.0 Primer                                       | {{<exlink url="https://drive.google.com/file/d/1i-Nk1YAcszAInU2YX_OtsARtLxSprLAJ/view?usp=sharing" text="1.4.0 Primer PDF">}}                   |
 | 1.4.0 Deployment Guide                             | {{<exlink url="https://drive.google.com/file/d/1uMjy-qUz9i1Vpi9E2EDeofjV0FzIlFos/view?usp=sharing" text="1.4.0 Deployment Guide PDF">}}                   |
 | 1.4.0 Image and Provisioning Management User Guide | {{<exlink url="https://drive.google.com/file/d/1-Dx_BdtIbMBv7wXMS13xtc7gFn0iEb_W/view?usp=sharing" text="1.4.0 Image and Provisioning Management User Guide PDF">}}                   |
@@ -64,6 +64,6 @@ If you are running a version of Cumulus Linux earlier than 3.6 or Cumulus NetQ e
 | 1.1.0                                              | {{<exlink url="https://drive.google.com/file/d/1AHt-a0yR2De7H3Wz-LB1ZETMMQkXl2Vx/view?usp=sharing" text="1.1.0 PDF">}}                   |
 | 1.0.0                                              | {{<exlink url="https://drive.google.com/file/d/1el6arIsVvKBiYKYYnc2wz_YJhpeRAhn-/view?usp=sharing" text="1.0.0 PDF">}}                   |
 
-## Cumulus Chassis PDF Archive
+<!-- ## Cumulus Chassis PDF Archive
 
-{{<exlink url="https://drive.google.com/open?id=1HgxfqpHPR4kQdlkRck98X7fXd9YE4oFh" text="Cumulus Chassis PDF">}}
+{{<exlink url="https://drive.google.com/open?id=1HgxfqpHPR4kQdlkRck98X7fXd9YE4oFh" text="Cumulus Chassis PDF">}} -->


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Remove the link to the chassis PDF
Add links to new URLs for 2.1.2 NetQ guides
Update links for big data and vSphere guides