### PR TITLE
Fix typo: asymmetric routing is not supported

### DIFF
--- a/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -82,7 +82,7 @@ EVPN multihoming supports the following route types.
 The following features are not supported with EVPN-MH:
 
 - {{<link url="Traditional-Bridge-Mode" text="Traditional bridge mode">}}
-- {{<link url="Inter-subnet-Routing/#symmetric-routing" text="Distributed symmetric routing">}}
+- {{<link url="Inter-subnet-Routing/#asymmetric-routing" text="Distributed asymmetric routing">}}
 - Head-end replication; use {{<link title="EVPN BUM Traffic with PIM-SM" text="EVPN-PIM">}} for BUM traffic handling instead
 
 ## Configure EVPN-MH

--- a/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -80,7 +80,7 @@ EVPN multihoming supports the following route types.
 The following features are not supported with EVPN-MH:
 
 - {{<link url="Traditional-Bridge-Mode" text="Traditional bridge mode">}}
-- {{<link url="Inter-subnet-Routing/#symmetric-routing" text="Distributed symmetric routing">}}
+- {{<link url="Inter-subnet-Routing/#asymmetric-routing" text="Distributed asymmetric routing">}}
 - Head-end replication; use {{<link title="EVPN BUM Traffic with PIM-SM" text="EVPN-PIM">}} for BUM traffic handling instead
 
 ## Configure EVPN-MH


### PR DESCRIPTION
Ticket: UD-2294
Reviewed By:
Testing Done:

Erroneously stated that symmetric routing was not supported with EVPN multihoming; it's actually asymmetric routing that isn't supported.