### PR TITLE
Smart System Manager supported on Spectrum ASICs only

### DIFF
--- a/content/cumulus-linux-43/System-Configuration/Smart-System-Manager.md
+++ b/content/cumulus-linux-43/System-Configuration/Smart-System-Manager.md
@@ -12,8 +12,10 @@ Smart System Manager includes the following modes:
 - Maintenance
 
 {{%notice note%}}
-The Smart System Manager is a Spectrum-only ASIC feature
-The Smart System Manager NCLU commands do not require a `net commit`.
+
+- The Smart System Manager is supported on Spectrum 1, 2 and 3 ASICs only.
+- The Smart System Manager NCLU commands do not require a `net commit`.
+
 {{%/notice%}}
 
 ## Restart Mode

--- a/content/cumulus-linux-50/System-Configuration/Smart-System-Manager.md
+++ b/content/cumulus-linux-50/System-Configuration/Smart-System-Manager.md
@@ -12,7 +12,10 @@ Smart System Manager includes the following modes:
 - Maintenance
 
 {{%notice note%}}
-The Smart System Manager NCLU commands do not require a `net commit`.
+
+- The Smart System Manager is supported on Spectrum 1, 2 and 3 ASICs only.
+- The Smart System Manager NCLU commands do not require a `net commit`.
+
 {{%/notice%}}
 
 ## Restart Mode


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

Update SSM docs to enumerate the versions of Spectrum that support it.