### PR TITLE
Static Routing: Fix interface name in VRF config

### DIFF
--- a/content/cumulus-linux-42/Layer-3/Routing/Static-Routing.md
+++ b/content/cumulus-linux-42/Layer-3/Routing/Static-Routing.md
@@ -77,7 +77,7 @@ The following example commands configure Cumulus Linux to send traffic with the 
 
 ```
 cumulus@border01:~$ net add interface swp3 ip address 10.0.0.32/31
-cumulus@border01:~$ net add interface swp51 vrf BLUE
+cumulus@border01:~$ net add interface swp3 vrf BLUE
 cumulus@border01:~$ net add routing route 10.10.10.61/32 10.0.0.33 vrf BLUE
 cumulus@border01:~$ net pending
 cumulus@border01:~$ net commit

--- a/content/cumulus-linux-43/Layer-3/Routing/Static-Routing.md
+++ b/content/cumulus-linux-43/Layer-3/Routing/Static-Routing.md
@@ -79,7 +79,7 @@ The following example commands configure Cumulus Linux to send traffic with the 
 
 ```
 cumulus@border01:~$ net add interface swp3 ip address 10.0.0.32/31
-cumulus@border01:~$ net add interface swp51 vrf BLUE
+cumulus@border01:~$ net add interface swp3 vrf BLUE
 cumulus@border01:~$ net add routing route 10.10.10.61/32 10.0.0.33 vrf BLUE
 cumulus@border01:~$ net pending
 cumulus@border01:~$ net commit

--- a/content/cumulus-linux-50/Layer-3/Routing/Static-Routing.md
+++ b/content/cumulus-linux-50/Layer-3/Routing/Static-Routing.md
@@ -94,7 +94,7 @@ cumulus@border01:~$ cl config apply
 
 ```
 cumulus@border01:~$ net add interface swp3 ip address 10.0.0.32/31
-cumulus@border01:~$ net add interface swp51 vrf BLUE
+cumulus@border01:~$ net add interface swp3 vrf BLUE
 cumulus@border01:~$ net add routing route 10.10.10.61/32 10.0.0.33 vrf BLUE
 cumulus@border01:~$ net pending
 cumulus@border01:~$ net commit


### PR DESCRIPTION
Fixes an incorrect interface name in the example for configuring static routing with VRFs. The interface used in the topology is `swp3` but the NCLU command incorrectly shows `swp51`.