### PR TITLE
breakouts update

### DIFF
--- a/content/cumulus-linux-44/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
+++ b/content/cumulus-linux-44/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
@@ -581,516 +581,518 @@ Cumulus Linux supports the following ports breakout options per platform
 
 {{< tabs "Platforms ">}}
 {{< tab "SN2010">}}
-SN2010 18xSFP+ (25GbE) and 4xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
-All 4xQSFP28 ports can breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+18x SFP+ 25G and 4x QSFP28 100G interfaces only support NRZ encoding. All speeds down to 1G are supported.<br>
+
+All 4x QSFP28 ports can breakout into 4x SFP28 or 2x QSFP28. 
 {{< tabs "2010_ports ">}}
 {{< tab "10G ">}}
-- 18x10G - 18xSFP28 set to 10G
-- 16x10G - 4xQSFP28 breakout into 4x25G and set to 10G
+- 18x 10G - 18x SFP28 set to 10G
+- 16x 10G - 4x QSFP28 configured as 4x25G breakouts and set to 10G
 
-Maximum 10G ports - 34 
+Maximum 10G ports: 34 
 {{< /tab >}}
 {{< tab "25G ">}}
-- 18x25G - 18xSFP28 (native speed)
-- 16x25G - 4xQSFP28 breakout into 4x25G
+- 18x 25G - 18x SFP28 (native speed)
+- 16x 25G - 4x QSFP28 breakouts to 4x25G
 
-Maximum 25G ports - 34
+Maximum 25G ports: 34
 {{< /tab >}}
 {{< tab "40G ">}}
-- 4x40G - 4xQSFP28 set to 40G
+- 4x 40G - 4x QSFP28 set to 40G
 
-Maximum 40G ports - 4
+Maximum 40G ports: 4
 {{< /tab >}}
 {{< tab "50G ">}}
-- 8x50G - 4xQSFP28 breakout into 2x50G
+- 8x 50G - 4x QSFP28 breakout into 2x 50G
 
-Maximum 50G ports - 8
+Maximum 50G ports: 8
 {{< /tab >}}
 {{< tab "100G ">}}
-- 4x100G - 4xQSFP28 (native speed)
+- 4x 100G - 4x QSFP28 (native speed)
 
-Maximum 100G ports - 4
+Maximum 100G ports: 4
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
+
 {{< tab "SN2100">}}
-SN2100 16xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
-All QSFP28 ports can be breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+16x QSFP28 100G interfaces only support NRZ encoding. All speeds down to 1G are supported.<br>
+All QSFP28 ports can breakout into 4x SFP28 or 2x QSFP28. 
 {{< tabs "2100_ports ">}}
 {{< tab "10G ">}}
-- 64x10G - 16xQSFP28 breakout into 4x25G and set to 10G
+- 64x 10G - 16x QSFP28 breakout into 4x 25G and set to 10G
 
-Maximum 10G ports - 64
+Maximum 10G ports: 64
 {{< /tab >}}
 {{< tab "25G ">}}
-- 64x25G - 16xQSFP28 breakout into 4x25G
+- 64x 25G - 16x QSFP28 breakout into 4x 25G
 
-Maximum 25G ports - 64
+Maximum 25G ports: 64
 {{< /tab >}}
 {{< tab "40G ">}}
-- 16x40G - 4xQSFP28 set to 40G
+- 16x 40G - 4x QSFP28 set to 40G
 
-Maximum 40G ports - 16
+Maximum 40G ports: 16
 {{< /tab >}}
 {{< tab "50G ">}}
-- 32x50G - 16xQSFP28 breakout into 2x50G 
+- 32x 50G - 16x QSFP28 breakout into 2x 50G 
 
-Maximum 50G ports - 32
+Maximum 50G ports: 32
 {{< /tab >}}
 {{< tab "100G ">}}
-- 16x100G - 16xQSFP28 (native speed)
+- 16x 100G - 16x QSFP28 (native speed)
 
-Maximum 100G ports - 16
+Maximum 100G ports: 16
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 {{< tab "SN2410">}}
-SN2410 48xSFP28 (25GbE) and 8xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
-The top 4xQSFP28 ports can breakout into 4xSFP28 (4x25GbE). But, in this case, the adjacent 4xQSFP28 ports will be blocked.<br> 
-All 8xQSFP28 ports can breakout into 2xQSFP28 (2x50GbE) without blocking ports. 
+48x SFP28 25G and 8x QSFP28 100G interfaces only support NRZ encoding. All speeds down to 1G are supported.<br>
+The top 4x QSFP28 ports can breakout into 4x SFP28. The lower 4x QSFP28 ports are disabled and can not be used.<br> 
+All 8x QSFP28 ports can breakout into 2x QSFP28 without disabling ports. 
 {{< tabs "2410_ports ">}}
 {{< tab "10G ">}}
-- 48x10G - 48xSFP28 set to 10G
-- 16x10G - 4xQSPF28 breakout into 4x25G and set to 10G
+- 48x 10G - 48x SFP28 set to 10G
+- 16x 10G - 4x QSPF28 breakout into 4x25G and set to 10G
 
-Maximum 10G ports - 64
+Maximum 10G ports: 64
 {{< /tab >}}
 {{< tab "25G ">}}
-- 48x25G - 48xSFP28 (native speed) 
-- 16x25G - Top 4xQSFP28 breakout into 4x25G (bottom 4xQSFP28 blocked)
+- 48x 25G - 48x SFP28 (native speed) 
+- 16x 25G - Top 4x QSFP28 breakout into 4x25G (bottom 4x QSFP28 disabled)
 
-Maximum 25G ports - 64
+Maximum 25G ports: 64
 {{< /tab >}}
 {{< tab "40G ">}}
-- 8x40G - 8xQSFP28 set to 40G
+- 8x 40G - 8x QSFP28 set to 40G
 
-Maximum 40G ports - 8
+Maximum 40G ports: 8
 {{< /tab >}}
 {{< tab "50G ">}}
-- 16x50G - 8xQSFP28 breakout into 2x50G
+- 16x 50G - 8x QSFP28 breakout into 2x 50G
 
-Maximum 50G ports - 16
+Maximum 50G ports: 16
 {{< /tab >}}
 {{< tab "100G ">}}
-- 8x100G - 16xQSFP28 (native speed)
+- 8x 100G - 16x QSFP28 (native speed)
 
-Maximum 100G ports - 8
+Maximum 100G ports: 8
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 {{< tab "SN2700">}}
-SN2700 32xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
-The top 16xQSFP28 ports can breakout into 4xSFP28 (4x25GbE). But, in this case, the adjacent 16xQSFP28 ports will be blocked.<br> 
-All 32xQSFP28 ports can breakout into 2xQSFP28 (2x50GbE) without blocking ports. 
+32x QSFP28 100G interfaces only support NRZ encoding. All speeds down to 1G are supported.<br>
+The top 16x QSFP28 ports can breakout into 4x SFP28. The lower 4x QSFP28 ports are disabled and can not be used.<br> 
+All 32x QSFP28 ports can breakout into 2x QSFP28 without disabling ports. 
 {{< tabs "2700_ports ">}}
 {{< tab "10G ">}}
-- 64x10G - Top 16xQSFP28 breakout into 4x25G and set to 10G (bottom 16xQSFP28 blocked)
+- 64x 10G - Top 16x QSFP28 breakout into 4x 25G and set to 10G (bottom 16x QSFP28 disabled)
 
-Maximum 10G ports - 64
+Maximum 10G ports: 64
 {{< /tab >}}
 {{< tab "25G ">}}
-- 64x25G - Top 16xQSFP28 breakout into 4x25G (bottom 16xQSFP28 blocked)
+- 64x 25G - Top 16x QSFP28 breakout into 4x25G (bottom 16x QSFP28 disabled)
 
-Maximum 25G ports - 64
+Maximum 25G ports: 64
 {{< /tab >}}
 {{< tab "40G ">}}
-- 32x40G - 32xQSFP28 set to 40G
+- 32x 40G - 32x QSFP28 set to 40G
 
-Maximum 40G ports - 32
+Maximum 40G ports: 32
 {{< /tab >}}
 {{< tab "50G ">}}
-- 64x50G - 64xQSFP28 breakout into 2x50G
+- 64x 50G - 64x QSFP28 breakout into 2x 50G
 
-Maximum 50G ports - 64
+Maximum 50G ports: 64
 {{< /tab >}}
 {{< tab "100G ">}}
-- 32x100G - 32xQSFP28 (native speed)
+- 32x 100G - 32x QSFP28 (native speed)
 
-Maximum 100G ports - 32
+Maximum 100G ports: 32
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 {{< tab "SN3420">}}
-SN3420 48xSFP28 (25GbE) and 12xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
-All 12xQSFP28 ports can breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+48x SFP28 25G and 12x QSFP28 100G interfaces only support NRZ encoding. All speeds down to 1G are supported.<br>
+All 12x QSFP28 ports can breakout into 4x SFP28 or 2x QSFP28. 
 {{< tabs "3420_ports ">}}
 {{< tab "10G ">}}
-- 48x10G - 48xSFP28 set to 10G
-- 48x10G - 12xQSPF28 breakout into 4x25G and set to 10G
+- 48x 10G - 48x SFP28 set to 10G
+- 48x 10G - 12x QSPF28 breakout into 4x 25G and set to 10G
 
-Maximum 10G ports - 96
+Maximum 10G ports: 96
 {{< /tab >}}
 {{< tab "25G ">}}
-- 48x25G - 48xSFP28 (native speed)
-- 48x25G - 12xQSPF28 breakout into 4x25G
+- 48x 25G - 48x SFP28 (native speed)
+- 48x 25G - 12x QSPF28 breakout into 4x 25G
 
-Maximum 25G ports - 96
+Maximum 25G ports: 96
 {{< /tab >}}
 {{< tab "40G ">}}
-- 12x40G - 12xQSFP28 set to 40G
+- 12x 40G - 12x QSFP28 set to 40G
 
-Maximum 40G ports - 12
+Maximum 40G ports: 12
 {{< /tab >}}
 {{< tab "50G ">}}
-- 24x50G - 12xQSFP28 breakout into 2x50G
+- 24x 50G - 12x QSFP28 breakout into 2x 50G
 
-Maximum 50G ports - 24
+Maximum 50G ports: 24
 {{< /tab >}}
 {{< tab "100G ">}}
-- 12x100G - 12xQSFP28 (native speed)
+- 12x 100G - 12x QSFP28 (native speed)
 
-Maximum 100G ports - 12
+Maximum 100G ports: 12
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 
 <!-- SN3510 PLATFORM DELAYED UNTILL FURTHER NOTICE
-{{< tab "SN3510">}}
+{< tab "SN3510">}}
 SN3510 48xSFP56 (50GbE) and 6xQSFP-DD (400GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br>
 For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
 All 6xQSFP-DD ports can breakout into 8xSFP56 (8x50GbE), 4xQSFP56 (4x100GbE), or 2xQSFP56 (2x200GbE). 
-{{< tabs "3510_ports ">}}
-{{< tab "10G ">}}
+{< tabs "3510_ports ">}}
+{< tab "10G ">}}
 - 48x10G - 48xSFP56 set to 10G
 - 48x10G - 6xQSFP-DD breakout into 8x50G and set to 10G
 
 Maximum 10G ports - 96
-{{< /tab >}}
-{{< tab "25G ">}}
+{< /tab >}}
+{< tab "25G ">}}
 - 48x25G - 48xSFP56 set to 25G
 - 48x25G - 6xQSPF-DD breakout into 8x50G and set to 25G
 
 Maximum 25G ports - 96
-{{< /tab >}}
-{{< tab "40G ">}}
+{< /tab >}}
+{< tab "40G ">}}
 - 12x40G - 12xQSFP-DD set to 40G
 
 Maximum 40G ports - 12
-{{< /tab >}}
-{{< tab "50G ">}}
+{< /tab >}}
+{< tab "50G ">}}
 - 48x50G - 48xSFP56 (native speed)
 - 48x50G - 6xQSFP-DD breakout into 8x50G
 
 Maximum 50G ports - 96
-{{< /tab >}}
-{{< tab "100G ">}}
+{< /tab >}}
+{< tab "100G ">}}
 - 24x100G - 6xQSFP-DD breakout into 4x100G
 
 Maximum 100G ports - 24
-{{< /tab >}}
-{{< tab "200G ">}}
+{< /tab >}}
+{< tab "200G ">}}
 - 12x200G - 6xQSFP-DD breakout into 4x200G
 
 Maximum 200G ports - 12
-{{< /tab >}}
-{{< tab "400G ">}}
+{< /tab >}}
+{< tab "400G ">}}
 - 6x400G - 6xQSFP-DD (native speed)
 
 Maximum 400G ports - 6
-{{< /tab >}}
-{{< /tab >}}
-{{< /tabs >}}
+{< /tab >}}
+{< /tab >}}
+{< /tabs >}}
 
 -->
 
 {{< tab "SN3700C">}}
-SN3700C 32xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
-All 32xQSFP28 ports can breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+32x QSFP28 100G interfaces only support NRZ encoding. All speeds down to 1G are supported.<br>
+All 32x QSFP28 ports can breakout into 4x SFP28 or 2x QSFP28. 
 {{< tabs "3700C_ports ">}}
 {{< tab "10G ">}}
-- 128x10G - 32xQSFP28 breakout into 4x25G and set to 10G
+- 128x 10G - 32x QSFP28 breakout into 4x 25G and set to 10G
 
-Maximum 10G ports - 128
+Maximum 10G ports: 128
 {{< /tab >}}
 {{< tab "25G ">}}
-- 128x25G - 32xQSFP28 breakout into 4x25G
+- 128x 25G - 32x QSFP28 breakout into 4x 25G
 
-Maximum 25G ports - 128
+Maximum 25G ports: 128
 {{< /tab >}}
 {{< tab "40G ">}}
-- 32x40G - 32xQSFP28 set to 40G
+- 32x 40G - 32x QSFP28 set to 40G
 
-Maximum 40G ports - 32
+Maximum 40G ports: 32
 {{< /tab >}}
 {{< tab "50G ">}}
-- 64x50G - 32xQSFP28 breakout into 2x50G
+- 64x 50G - 32x QSFP28 breakout into 2x 50G
 
-Maximum 50G ports - 64
+Maximum 50G ports: 64
 {{< /tab >}}
 {{< tab "100G ">}}
-- 32x100G - 32xQSFP28 (native speed)
+- 32x 100G - 32x QSFP28 (native speed)
 
-Maximum 32G ports - 32
+Maximum 100G ports: 32
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 {{< tab "SN3700">}}
-SN3700 32xQSFP56 (200GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br>
-For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
-All 32xQSFP56 ports can breakout into 4xSFP56 (4x50GbE) or 2xQSFP56 (2x100GbE). 
+32x QSFP56 200G interfaces support both PAM4 and NRZ encodings. All speeds down to 1G are supported.<br>
+For lower speed interface configurations, PAM4 is automatically converted to NRZ encoding.<br>
+All 32x QSFP56 ports can breakout into 4xSFP56 or 2x QSFP56. 
 {{< tabs "3700_ports ">}}
 {{< tab "10G ">}}
-- 128x10G - 32xQSFP56 breakout into 4x50G and set to 10G
+- 128x 10G - 32x QSFP56 breakout into 4x 50G and set to 10G
 
-Maximum 10G ports - 128
+Maximum 10G ports: 128
 {{< /tab >}}
 {{< tab "25G ">}}
-- 128x25G - 32xQSFP56 breakout into 4x50G and set to 25G
+- 128x 25G - 32x QSFP56 breakout into 4x 50G and set to 25G
 
-Maximum 25G ports - 128
+Maximum 25G ports: 128
 {{< /tab >}}
 {{< tab "40G ">}}
-- 32x40G - 32xQSFP56 set to 40G
+- 32x 40G - 32x QSFP56 set to 40G
 
-Maximum 32G ports - 32
+Maximum 40G ports: 32
 {{< /tab >}}
 {{< tab "50G ">}}
-- 128x50G - 32xQSFP56 breakout into 4x50G
+- 128x 50G - 32x QSFP56 breakout into 4x 50G
 
-Maximum 50G ports - 128
+Maximum 50G ports: 128
 {{< /tab >}}
 {{< tab "100G ">}}
-- 64x100G - 32xQSFP56 breakout into 2x100G
+- 64x 100G - 32x QSFP56 breakout into 2x 100G
 
-Maximum 100G ports - 64
+Maximum 100G ports: 64
 {{< /tab >}}
 {{< tab "200G ">}}
-- 32x200G - 32xQSFP56 (native speed)
+- 32x 200G - 32x QSFP56 (native speed)
 
-Maximum 200G ports - 32
+Maximum 200G ports: 32
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 
 <!-- SN4410 PLATFORM IS PLANNED TO AUG21 (CL4.4.1?)
 
-{{< tab "SN4410">}}
+{< tab "SN4410">}}
 SN4410 24xQSFP28-DD (100GbE) interfaces [ports 1-24] only support NRZ encoding and wll speeds down to 1G.<br> 
 The 8xQSFP-DD (400GbE) interfaces [ports 25-32] support both PAM4 and NRZ encodings with all speeds down to 1G.<br> 
 For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
 The 24xQSFP28-DD ports can breakout into 2xQSFP28 (2x100GbE) using special 2x100GbE breakout cable, or 4xSFP28 (4x25GbE).<br> 
 The top 4xQSFP-DD ports can breakout into 8xSFP56 (8x50GbE). But, in this case, the adjacent 4xQSFP-DD ports will be blocked.<br> 
 All the 8xQSFP-DD ports can breakout into 4xQSFP56 (4x100GbE), or 2xQSFP56 (2x200GbE) without blocking ports.
-{{< tabs "4410_ports ">}}
-{{< tab "10G ">}}
+{< tabs "4410_ports ">}}
+{< tab "10G ">}}
 - 96x10G - 24xQSFP28-DD breakout into 4x25G and set to 10G
 - 32x10G - 4 top QSFP-DD breakout into 8x50G and set to 10G (bottom 4xQSFP-DD blocked*)
 
 Maximum 10G ports - 128<br>
 *Other QSFP-DD breakout combinations are available up to maximum of 128x10G ports.
-{{< /tab >}}
-{{< tab "25G ">}}
+{< /tab >}}
+{< tab "25G ">}}
 - 96x25G - 24xQSFP28-DD breakout into 4x25G
 - 32x25G - 4 top QSFP-DD breakout into 8x50G and set to 25G (bottom 4xQSFP-DD blocked*)
 
 Maximum 25G ports - 128<br>
 *Other QSFP-DD breakout combinations are available up to maximum of 128x25G ports.
-{{< /tab >}}
-{{< tab "40G ">}}
+{< /tab >}}
+{< tab "40G ">}}
 - 32x40G - 24xQSFP28-DD and 8xQSFP-DD set to 40G
 
 Maximum 40G ports - 32
-{{< /tab >}}
-{{< tab "50G ">}}
+{< /tab >}}
+{< tab "50G ">}}
 - 48x50G - 24xQSFP28-DD breakout into 2x50G
 - 32x50G - 4 top QSFP-DD breakout into 8x50G (bottom 4xQSFP-DD blocked*)
 
 Maximum 50G ports - 80<br>
 *Other QSFP-DD breakout combinations are available up to maximum of 80x50G ports.
-{{< /tab >}}
-{{< tab "100G ">}}
+{< /tab >}}
+{< tab "100G ">}}
 - 48x100G - 24xQSFP28-DD breakout into 2x100G (using special 2xQSFP28-DD breakout cable)
 - 32x100G - 8xQSFP-DD breakout into 4x100G
 
 Maximum 100G ports - 80
-{{< /tab >}}
-{{< tab "200G ">}}
+{< /tab >}}
+{< tab "200G ">}}
 - 16x200G - 8xQSFP-DD breakout into 2x200G
 
 Maximum 200G ports - 16
-{{< /tab >}}
-{{< tab "400G ">}}
+{< /tab >}}
+{< tab "400G ">}}
 - 8x400G - 8xQSFP-DD (native speed)
 
 Maximum 400G ports - 8
-{{< /tab >}}
-{{< /tab >}}
-{{< /tabs >}}
+{< /tab >}}
+{< /tab >}}
+{< /tabs >}}
 
 -->
 
 {{< tab "SN4600C">}}
-SN4600C 64xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
-Only 32xQSFP28 ports can breakout into 4xSFP28 (4x25GbE). But, in this case, the adjacent QSFP28 port will be blocked (only the 1st/3rd or 2nd/4th rows can breakout into 4xSFP28).<br>
-All 64xQSFP28 ports can breakout into 2xQSFP28 (2x50GbE) without blocking ports. 
+64x QSFP28 100G interfaces only support NRZ encoding. All speeds down to 1G are supported.<br>
+Only 32x QSFP28 ports can breakout into 4x SFP28. The adjacent QSFP28 port will be disabled. Only the first and third or second and forth rows can breakout into 4xSFP28.<br>
+All 64x QSFP28 ports can breakout into 2x QSFP28 without disabling ports. 
 {{< tabs "4600C_ports ">}}
 {{< tab "10G ">}}
-- 128x10G - 32xQSFP28 breakout into 4x25G and set to 10G
+- 128x 10G - 32x QSFP28 breakout into 4x 25G and set to 10G
 
-Maximum 10G ports - 128
+Maximum 10G ports: 128
 {{< /tab >}}
 {{< tab "25G ">}}
-- 128x25G - 32xQSFP28 breakout into 4x25G
+- 128x 25G - 32x QSFP28 breakout into 4x 25G
 
-Maximum 25G ports - 128
+Maximum 25G ports: 128
 {{< /tab >}}
 {{< tab "40G ">}}
-- 64x40G - 64xQSFP28 set to 40G
+- 64x 40G - 64x QSFP28 set to 40G
 
-Maximum 40G ports - 64
+Maximum 40G ports: 64
 {{< /tab >}}
 {{< tab "50G ">}}
-- 128x50G - 64xQSFP28 breakout into 2x50G
+- 128x 50G - 64x QSFP28 breakout into 2x 50G
 
-Maximum 50G ports - 128
+Maximum 50G ports: 128
 {{< /tab >}}
 {{< tab "100G ">}}
-- 64x100G - 64xQSFP28 (native speed)
+- 64x 100G - 64x QSFP28 (native speed)
 
-Maximum 100G ports - 80
+Maximum 100G ports: 80
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 
 <!-- SN4600 PLATFORM IS PLANNED TO AUG21 (CL4.4.1?)
 
-{{< tab "SN4600">}}
+{< tab "SN4600">}}
 SN4600 64xQSFP56 (200GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br>
 For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
 Only 32xQSFP56 ports can breakout into 4xSFP56 (4x50GbE). But, in this case, the adjacent QSFP56 port will be blocked (only the 1st/3rd or 2nd/4th rows can breakout into 4xSFP56).<br>
 All 64xQSFP56 ports can breakout into 2xQSFP56 (2x100GbE) without blocking ports. 
-{{< tabs "4600_ports ">}}
-{{< tab "10G ">}}
+{< tabs "4600_ports ">}}
+{< tab "10G ">}}
 - 128x10G - 64xQSFP56 breakout into 4x50G and set to 10G
 
 Maximum 10G ports - 128
-{{< /tab >}}
-{{< tab "25G ">}}
+{< /tab >}}
+{< tab "25G ">}}
 - 128x25G - 64xQSFP56 breakout into 4x50G and set to 25G
 
 Maximum 25G ports - 128
-{{< /tab >}}
-{{< tab "40G ">}}
+{< /tab >}}
+{< tab "40G ">}}
 - 64x40G - 64xQSFP56 set to 40G
 
 Maximum 40G ports - 64
-{{< /tab >}}
-{{< tab "50G ">}}
+{< /tab >}}
+{< tab "50G ">}}
 - 128x50G - 32xQSFP56 breakout into 4x50G
 
 Maximum 50G ports - 128
-{{< /tab >}}
-{{< tab "100G ">}}
+{< /tab >}}
+{< tab "100G ">}}
 - 128x100G - 64xQSFP56 breakout into 2x100G
 - 64x100G - 64xQSFP28 set to 100G
 
 Maximum 100G ports - 128
-{{< /tab >}}
-{{< tab "200G ">}}
+{< /tab >}}
+{< tab "200G ">}}
 - 64x200G - 64xQSFP56 (native speed)
 
 Maximum 200G ports - 64
-{{< /tab >}}
-{{< /tab >}}
-{{< /tabs >}}
+{< /tab >}}
+{< /tab >}}
+{< /tabs >}}
 
 -->
 
 {{< tab "SN4700">}}
-SN4700 32xQSFP-DD (400GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br> 
-For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
-Only the top or the bottom 16xQSFP-DD ports can breakout into 8xSFP56 (8x50GbE). But, in this case, the adjacent 16xQSFP-DD ports will be blocked.<br> 
-All 32xQSFP-DD ports can breakout into 2xQSFP56 (2x200GbE) or 4xQSFP56 (4x100GbE) without blocking ports.
+SN4700 32x QSFP-DD 400GbE interfaces support both PAM4 and NRZ encodings. All speeds down to 1G are supported.<br> 
+For lower speed interface configurations, PAM4 is automatically converted to NRZ encoding.<br>
+Only the top or the bottom 16x QSFP-DD ports can breakout into 8x SFP56. The adjacent QSFP-DD port will be disabled.<br> 
+All 32x QSFP-DD ports can breakout into 2x QSFP56 at 2x200G or 4x QSFP56 at 4x 100G without disabling ports.
 {{< tabs "4700_ports ">}}
 {{< tab "10G ">}}
-- 128x10G - 16xQSFP-DD breakout into 8x50G and set to 10G
+- 128x 10G - 16x QSFP-DD breakout into 8x 50G and set to 10G
 
-Maximum 10G ports - 128<br>
-*Other QSFP-DD breakout combinations are available up to maximum of 128x10G ports.
+Maximum 10G ports: 128<br>
+*Other QSFP-DD breakout combinations are supported up to maximum of 128x 10G ports.
 {{< /tab >}}
 {{< tab "25G ">}}
-- 128x25G - 16xQSFP-DD* breakout into 8x50G and set to 25G
+- 128x 25G - 16x QSFP-DD breakout into 8x 50G and set to 25G
 
-Maximum 25G ports - 128<br>
-*Other QSFP-DD breakout combinations are available up to maximum of 128x25G ports.
+Maximum 25G ports: 128<br>
+*Other QSFP-DD breakout combinations are supported up to maximum of 128x 25G ports.
 {{< /tab >}}
 {{< tab "40G ">}}
-- 32x40G - 32xQSFP-DD set to 40G
+- 32x 40G - 32x QSFP-DD set to 40G
 
-Maximum 40G ports - 32
+Maximum 40G ports: 32
 {{< /tab >}}
 {{< tab "50G ">}}
-- 128x50G - 16xQSFP-DD* breakout into 8x50G
+- 128x 50G - 16x QSFP-DD breakout into 8x 50G
 
-Maximum 50G ports - 128<br>
-*Other QSFP-DD breakout combinations are available up to maximum of 128x50G ports.
+Maximum 50G ports: 128<br>
+*Other QSFP-DD breakout combinations are supported up to maximum of 128x 50G ports.
 {{< /tab >}}
 {{< tab "100G ">}}
-- 128x100G - 32xQSFP-DD breakout into 4x100G
+- 128x 100G - 32x QSFP-DD breakout into 4x 100G
 
-Maximum 100G ports - 128
+Maximum 100G ports: 128
 {{< /tab >}}
 {{< tab "200G ">}}
-- 64x200G - 64xQSFP-DD breakout into 2x200G
+- 64x 200G - 64x QSFP-DD breakout into 2x 200G
 
-Maximum 200G ports - 64
+Maximum 200G ports: 64
 {{< /tab >}}
 {{< tab "400G ">}}
-- 32x400G - 32xQSFP-DD (native speed)
+- 32x 400G - 32x QSFP-DD (native speed)
 
-Maximum 400G ports - 32
+Maximum 400G ports: 32
 {{< /tab >}}
 {{< /tab >}}
 {{< /tabs >}}
 
 <!-- SN4800 PLATFORM IS PLANNED TO NOV21 (CL5.0?)
 
-{{< tab "SN4800">}}
+{< tab "SN4800">}}
 SN4800 is a modular chassis with up to 8 line-cards. Each line-card can have up to 16 MAC addresses. Thus, each can be of a different port form-factor and speed.<br> 
 All line-cards supports both NRZ and PAM4 encodings with speeds down to 1G. For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
-{{< tabs "4800_ports ">}}
-{{< tab "10G ">}}
+{< tabs "4800_ports ">}}
+{< tab "10G ">}}
 - 128x10G - 8 line-cards of 16xQSFP28* breakout into 4x25G and set to 10G
 
 Maximum 10G ports - 128<br>
 *Other combinations are possible by using higher-speed line-card with breakouts (up to 128x10G ports).
-{{< /tab >}}
-{{< tab "25G ">}}
+{< /tab >}}
+{< tab "25G ">}}
 - 128x25G - 8 line-cards of 16xQSFP28* breakout into 4x25G
 
 Maximum 25G ports - 128<br>
 *Other combinations are possible by using higher-speed line-card with breakouts (up to 128x25G ports). 
-{{< /tab >}}
-{{< tab "40G ">}}
+{< /tab >}}
+{< tab "40G ">}}
 - 128x40G - 8 line-cards of 16xQSFP28 set to 40G
 
 Maximum 40G ports - 128
-{{< /tab >}}
-{{< tab "50G ">}}
+{< /tab >}}
+{< tab "50G ">}}
 - 128x50G - 8 line-cards of 8xQSFP56* breakout into 4x50G
 
 Maximum 50G ports - 128<br>
 *Other combinations are possible by using higher-speed line-card with breakouts (up to 128x50G ports). 
-{{< /tab >}}
-{{< tab "100G ">}}
+{< /tab >}}
+{< tab "100G ">}}
 - 128x100G - 8 line-cards of 16xQSFP28* (native speed)
 
 Maximum 100G ports - 128<br>
 *Other combinations are possible by using higher-speed line-card with breakouts (up to 128x100G ports). 
-{{< /tab >}}
-{{< tab "200G ">}}
+{< /tab >}}
+{< tab "200G ">}}
 - 64x200G - 8 line-cards of 8xQSFP56* (native speed)
 
 Maximum 200G ports - 64<br>
 *Other combinations arepossible by using higher-speed line-card with breakouts (up to 64x200G ports). 
-{{< /tab >}}
-{{< tab "400G ">}}
+{< /tab >}}
+{< tab "400G ">}}
 - 32x400G - 8 line-cards of 4xQSFP-DD (native speed)
 
 Maximum 400G ports - 32
-{{< /tab >}}
-{{< /tab >}}
-{{< /tabs >}}
+{< /tab >}}
+{< /tab >}}
+{< /tabs >}}
 
 -->
 

--- a/content/cumulus-linux-44/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
+++ b/content/cumulus-linux-44/Layer-1-and-Switch-Ports/Interface-Configuration-and-Management/Switch-Port-Attributes.md
@@ -577,9 +577,524 @@ Setting the default MTU also applies to the management interface. Be sure to add
 
 ## Breakout Ports
 
-Cumulus Linux lets you:
-- Break out 100G switch ports into 2x50G, 4x25G, or 4x10G with breakout cables.
-- Break out 40G switch ports into four separate 10G ports (4x10G) for use with breakout cables.
+Cumulus Linux supports the following ports breakout options per platform
+
+{{< tabs "Platforms ">}}
+{{< tab "SN2010">}}
+SN2010 18xSFP+ (25GbE) and 4xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
+All 4xQSFP28 ports can breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+{{< tabs "2010_ports ">}}
+{{< tab "10G ">}}
+- 18x10G - 18xSFP28 set to 10G
+- 16x10G - 4xQSFP28 breakout into 4x25G and set to 10G
+
+Maximum 10G ports - 34 
+{{< /tab >}}
+{{< tab "25G ">}}
+- 18x25G - 18xSFP28 (native speed)
+- 16x25G - 4xQSFP28 breakout into 4x25G
+
+Maximum 25G ports - 34
+{{< /tab >}}
+{{< tab "40G ">}}
+- 4x40G - 4xQSFP28 set to 40G
+
+Maximum 40G ports - 4
+{{< /tab >}}
+{{< tab "50G ">}}
+- 8x50G - 4xQSFP28 breakout into 2x50G
+
+Maximum 50G ports - 8
+{{< /tab >}}
+{{< tab "100G ">}}
+- 4x100G - 4xQSFP28 (native speed)
+
+Maximum 100G ports - 4
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+{{< tab "SN2100">}}
+SN2100 16xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
+All QSFP28 ports can be breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+{{< tabs "2100_ports ">}}
+{{< tab "10G ">}}
+- 64x10G - 16xQSFP28 breakout into 4x25G and set to 10G
+
+Maximum 10G ports - 64
+{{< /tab >}}
+{{< tab "25G ">}}
+- 64x25G - 16xQSFP28 breakout into 4x25G
+
+Maximum 25G ports - 64
+{{< /tab >}}
+{{< tab "40G ">}}
+- 16x40G - 4xQSFP28 set to 40G
+
+Maximum 40G ports - 16
+{{< /tab >}}
+{{< tab "50G ">}}
+- 32x50G - 16xQSFP28 breakout into 2x50G 
+
+Maximum 50G ports - 32
+{{< /tab >}}
+{{< tab "100G ">}}
+- 16x100G - 16xQSFP28 (native speed)
+
+Maximum 100G ports - 16
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+{{< tab "SN2410">}}
+SN2410 48xSFP28 (25GbE) and 8xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
+The top 4xQSFP28 ports can breakout into 4xSFP28 (4x25GbE). But, in this case, the adjacent 4xQSFP28 ports will be blocked.<br> 
+All 8xQSFP28 ports can breakout into 2xQSFP28 (2x50GbE) without blocking ports. 
+{{< tabs "2410_ports ">}}
+{{< tab "10G ">}}
+- 48x10G - 48xSFP28 set to 10G
+- 16x10G - 4xQSPF28 breakout into 4x25G and set to 10G
+
+Maximum 10G ports - 64
+{{< /tab >}}
+{{< tab "25G ">}}
+- 48x25G - 48xSFP28 (native speed) 
+- 16x25G - Top 4xQSFP28 breakout into 4x25G (bottom 4xQSFP28 blocked)
+
+Maximum 25G ports - 64
+{{< /tab >}}
+{{< tab "40G ">}}
+- 8x40G - 8xQSFP28 set to 40G
+
+Maximum 40G ports - 8
+{{< /tab >}}
+{{< tab "50G ">}}
+- 16x50G - 8xQSFP28 breakout into 2x50G
+
+Maximum 50G ports - 16
+{{< /tab >}}
+{{< tab "100G ">}}
+- 8x100G - 16xQSFP28 (native speed)
+
+Maximum 100G ports - 8
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+{{< tab "SN2700">}}
+SN2700 32xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
+The top 16xQSFP28 ports can breakout into 4xSFP28 (4x25GbE). But, in this case, the adjacent 16xQSFP28 ports will be blocked.<br> 
+All 32xQSFP28 ports can breakout into 2xQSFP28 (2x50GbE) without blocking ports. 
+{{< tabs "2700_ports ">}}
+{{< tab "10G ">}}
+- 64x10G - Top 16xQSFP28 breakout into 4x25G and set to 10G (bottom 16xQSFP28 blocked)
+
+Maximum 10G ports - 64
+{{< /tab >}}
+{{< tab "25G ">}}
+- 64x25G - Top 16xQSFP28 breakout into 4x25G (bottom 16xQSFP28 blocked)
+
+Maximum 25G ports - 64
+{{< /tab >}}
+{{< tab "40G ">}}
+- 32x40G - 32xQSFP28 set to 40G
+
+Maximum 40G ports - 32
+{{< /tab >}}
+{{< tab "50G ">}}
+- 64x50G - 64xQSFP28 breakout into 2x50G
+
+Maximum 50G ports - 64
+{{< /tab >}}
+{{< tab "100G ">}}
+- 32x100G - 32xQSFP28 (native speed)
+
+Maximum 100G ports - 32
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+{{< tab "SN3420">}}
+SN3420 48xSFP28 (25GbE) and 12xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
+All 12xQSFP28 ports can breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+{{< tabs "3420_ports ">}}
+{{< tab "10G ">}}
+- 48x10G - 48xSFP28 set to 10G
+- 48x10G - 12xQSPF28 breakout into 4x25G and set to 10G
+
+Maximum 10G ports - 96
+{{< /tab >}}
+{{< tab "25G ">}}
+- 48x25G - 48xSFP28 (native speed)
+- 48x25G - 12xQSPF28 breakout into 4x25G
+
+Maximum 25G ports - 96
+{{< /tab >}}
+{{< tab "40G ">}}
+- 12x40G - 12xQSFP28 set to 40G
+
+Maximum 40G ports - 12
+{{< /tab >}}
+{{< tab "50G ">}}
+- 24x50G - 12xQSFP28 breakout into 2x50G
+
+Maximum 50G ports - 24
+{{< /tab >}}
+{{< tab "100G ">}}
+- 12x100G - 12xQSFP28 (native speed)
+
+Maximum 100G ports - 12
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+<!-- SN3510 PLATFORM DELAYED UNTILL FURTHER NOTICE
+{{< tab "SN3510">}}
+SN3510 48xSFP56 (50GbE) and 6xQSFP-DD (400GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br>
+For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
+All 6xQSFP-DD ports can breakout into 8xSFP56 (8x50GbE), 4xQSFP56 (4x100GbE), or 2xQSFP56 (2x200GbE). 
+{{< tabs "3510_ports ">}}
+{{< tab "10G ">}}
+- 48x10G - 48xSFP56 set to 10G
+- 48x10G - 6xQSFP-DD breakout into 8x50G and set to 10G
+
+Maximum 10G ports - 96
+{{< /tab >}}
+{{< tab "25G ">}}
+- 48x25G - 48xSFP56 set to 25G
+- 48x25G - 6xQSPF-DD breakout into 8x50G and set to 25G
+
+Maximum 25G ports - 96
+{{< /tab >}}
+{{< tab "40G ">}}
+- 12x40G - 12xQSFP-DD set to 40G
+
+Maximum 40G ports - 12
+{{< /tab >}}
+{{< tab "50G ">}}
+- 48x50G - 48xSFP56 (native speed)
+- 48x50G - 6xQSFP-DD breakout into 8x50G
+
+Maximum 50G ports - 96
+{{< /tab >}}
+{{< tab "100G ">}}
+- 24x100G - 6xQSFP-DD breakout into 4x100G
+
+Maximum 100G ports - 24
+{{< /tab >}}
+{{< tab "200G ">}}
+- 12x200G - 6xQSFP-DD breakout into 4x200G
+
+Maximum 200G ports - 12
+{{< /tab >}}
+{{< tab "400G ">}}
+- 6x400G - 6xQSFP-DD (native speed)
+
+Maximum 400G ports - 6
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+-->
+
+{{< tab "SN3700C">}}
+SN3700C 32xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
+All 32xQSFP28 ports can breakout into 4xSFP28 (4x25GbE) or 2xQSFP28 (2x50GbE). 
+{{< tabs "3700C_ports ">}}
+{{< tab "10G ">}}
+- 128x10G - 32xQSFP28 breakout into 4x25G and set to 10G
+
+Maximum 10G ports - 128
+{{< /tab >}}
+{{< tab "25G ">}}
+- 128x25G - 32xQSFP28 breakout into 4x25G
+
+Maximum 25G ports - 128
+{{< /tab >}}
+{{< tab "40G ">}}
+- 32x40G - 32xQSFP28 set to 40G
+
+Maximum 40G ports - 32
+{{< /tab >}}
+{{< tab "50G ">}}
+- 64x50G - 32xQSFP28 breakout into 2x50G
+
+Maximum 50G ports - 64
+{{< /tab >}}
+{{< tab "100G ">}}
+- 32x100G - 32xQSFP28 (native speed)
+
+Maximum 32G ports - 32
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+{{< tab "SN3700">}}
+SN3700 32xQSFP56 (200GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br>
+For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
+All 32xQSFP56 ports can breakout into 4xSFP56 (4x50GbE) or 2xQSFP56 (2x100GbE). 
+{{< tabs "3700_ports ">}}
+{{< tab "10G ">}}
+- 128x10G - 32xQSFP56 breakout into 4x50G and set to 10G
+
+Maximum 10G ports - 128
+{{< /tab >}}
+{{< tab "25G ">}}
+- 128x25G - 32xQSFP56 breakout into 4x50G and set to 25G
+
+Maximum 25G ports - 128
+{{< /tab >}}
+{{< tab "40G ">}}
+- 32x40G - 32xQSFP56 set to 40G
+
+Maximum 32G ports - 32
+{{< /tab >}}
+{{< tab "50G ">}}
+- 128x50G - 32xQSFP56 breakout into 4x50G
+
+Maximum 50G ports - 128
+{{< /tab >}}
+{{< tab "100G ">}}
+- 64x100G - 32xQSFP56 breakout into 2x100G
+
+Maximum 100G ports - 64
+{{< /tab >}}
+{{< tab "200G ">}}
+- 32x200G - 32xQSFP56 (native speed)
+
+Maximum 200G ports - 32
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+<!-- SN4410 PLATFORM IS PLANNED TO AUG21 (CL4.4.1?)
+
+{{< tab "SN4410">}}
+SN4410 24xQSFP28-DD (100GbE) interfaces [ports 1-24] only support NRZ encoding and wll speeds down to 1G.<br> 
+The 8xQSFP-DD (400GbE) interfaces [ports 25-32] support both PAM4 and NRZ encodings with all speeds down to 1G.<br> 
+For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
+The 24xQSFP28-DD ports can breakout into 2xQSFP28 (2x100GbE) using special 2x100GbE breakout cable, or 4xSFP28 (4x25GbE).<br> 
+The top 4xQSFP-DD ports can breakout into 8xSFP56 (8x50GbE). But, in this case, the adjacent 4xQSFP-DD ports will be blocked.<br> 
+All the 8xQSFP-DD ports can breakout into 4xQSFP56 (4x100GbE), or 2xQSFP56 (2x200GbE) without blocking ports.
+{{< tabs "4410_ports ">}}
+{{< tab "10G ">}}
+- 96x10G - 24xQSFP28-DD breakout into 4x25G and set to 10G
+- 32x10G - 4 top QSFP-DD breakout into 8x50G and set to 10G (bottom 4xQSFP-DD blocked*)
+
+Maximum 10G ports - 128<br>
+*Other QSFP-DD breakout combinations are available up to maximum of 128x10G ports.
+{{< /tab >}}
+{{< tab "25G ">}}
+- 96x25G - 24xQSFP28-DD breakout into 4x25G
+- 32x25G - 4 top QSFP-DD breakout into 8x50G and set to 25G (bottom 4xQSFP-DD blocked*)
+
+Maximum 25G ports - 128<br>
+*Other QSFP-DD breakout combinations are available up to maximum of 128x25G ports.
+{{< /tab >}}
+{{< tab "40G ">}}
+- 32x40G - 24xQSFP28-DD and 8xQSFP-DD set to 40G
+
+Maximum 40G ports - 32
+{{< /tab >}}
+{{< tab "50G ">}}
+- 48x50G - 24xQSFP28-DD breakout into 2x50G
+- 32x50G - 4 top QSFP-DD breakout into 8x50G (bottom 4xQSFP-DD blocked*)
+
+Maximum 50G ports - 80<br>
+*Other QSFP-DD breakout combinations are available up to maximum of 80x50G ports.
+{{< /tab >}}
+{{< tab "100G ">}}
+- 48x100G - 24xQSFP28-DD breakout into 2x100G (using special 2xQSFP28-DD breakout cable)
+- 32x100G - 8xQSFP-DD breakout into 4x100G
+
+Maximum 100G ports - 80
+{{< /tab >}}
+{{< tab "200G ">}}
+- 16x200G - 8xQSFP-DD breakout into 2x200G
+
+Maximum 200G ports - 16
+{{< /tab >}}
+{{< tab "400G ">}}
+- 8x400G - 8xQSFP-DD (native speed)
+
+Maximum 400G ports - 8
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+-->
+
+{{< tab "SN4600C">}}
+SN4600C 64xQSFP28 (100GbE) interfaces only support NRZ encoding and all speeds down to 1G.<br>
+Only 32xQSFP28 ports can breakout into 4xSFP28 (4x25GbE). But, in this case, the adjacent QSFP28 port will be blocked (only the 1st/3rd or 2nd/4th rows can breakout into 4xSFP28).<br>
+All 64xQSFP28 ports can breakout into 2xQSFP28 (2x50GbE) without blocking ports. 
+{{< tabs "4600C_ports ">}}
+{{< tab "10G ">}}
+- 128x10G - 32xQSFP28 breakout into 4x25G and set to 10G
+
+Maximum 10G ports - 128
+{{< /tab >}}
+{{< tab "25G ">}}
+- 128x25G - 32xQSFP28 breakout into 4x25G
+
+Maximum 25G ports - 128
+{{< /tab >}}
+{{< tab "40G ">}}
+- 64x40G - 64xQSFP28 set to 40G
+
+Maximum 40G ports - 64
+{{< /tab >}}
+{{< tab "50G ">}}
+- 128x50G - 64xQSFP28 breakout into 2x50G
+
+Maximum 50G ports - 128
+{{< /tab >}}
+{{< tab "100G ">}}
+- 64x100G - 64xQSFP28 (native speed)
+
+Maximum 100G ports - 80
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+<!-- SN4600 PLATFORM IS PLANNED TO AUG21 (CL4.4.1?)
+
+{{< tab "SN4600">}}
+SN4600 64xQSFP56 (200GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br>
+For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
+Only 32xQSFP56 ports can breakout into 4xSFP56 (4x50GbE). But, in this case, the adjacent QSFP56 port will be blocked (only the 1st/3rd or 2nd/4th rows can breakout into 4xSFP56).<br>
+All 64xQSFP56 ports can breakout into 2xQSFP56 (2x100GbE) without blocking ports. 
+{{< tabs "4600_ports ">}}
+{{< tab "10G ">}}
+- 128x10G - 64xQSFP56 breakout into 4x50G and set to 10G
+
+Maximum 10G ports - 128
+{{< /tab >}}
+{{< tab "25G ">}}
+- 128x25G - 64xQSFP56 breakout into 4x50G and set to 25G
+
+Maximum 25G ports - 128
+{{< /tab >}}
+{{< tab "40G ">}}
+- 64x40G - 64xQSFP56 set to 40G
+
+Maximum 40G ports - 64
+{{< /tab >}}
+{{< tab "50G ">}}
+- 128x50G - 32xQSFP56 breakout into 4x50G
+
+Maximum 50G ports - 128
+{{< /tab >}}
+{{< tab "100G ">}}
+- 128x100G - 64xQSFP56 breakout into 2x100G
+- 64x100G - 64xQSFP28 set to 100G
+
+Maximum 100G ports - 128
+{{< /tab >}}
+{{< tab "200G ">}}
+- 64x200G - 64xQSFP56 (native speed)
+
+Maximum 200G ports - 64
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+-->
+
+{{< tab "SN4700">}}
+SN4700 32xQSFP-DD (400GbE) interfaces support both PAM4 and NRZ encodings with all speeds down to 1G.<br> 
+For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
+Only the top or the bottom 16xQSFP-DD ports can breakout into 8xSFP56 (8x50GbE). But, in this case, the adjacent 16xQSFP-DD ports will be blocked.<br> 
+All 32xQSFP-DD ports can breakout into 2xQSFP56 (2x200GbE) or 4xQSFP56 (4x100GbE) without blocking ports.
+{{< tabs "4700_ports ">}}
+{{< tab "10G ">}}
+- 128x10G - 16xQSFP-DD breakout into 8x50G and set to 10G
+
+Maximum 10G ports - 128<br>
+*Other QSFP-DD breakout combinations are available up to maximum of 128x10G ports.
+{{< /tab >}}
+{{< tab "25G ">}}
+- 128x25G - 16xQSFP-DD* breakout into 8x50G and set to 25G
+
+Maximum 25G ports - 128<br>
+*Other QSFP-DD breakout combinations are available up to maximum of 128x25G ports.
+{{< /tab >}}
+{{< tab "40G ">}}
+- 32x40G - 32xQSFP-DD set to 40G
+
+Maximum 40G ports - 32
+{{< /tab >}}
+{{< tab "50G ">}}
+- 128x50G - 16xQSFP-DD* breakout into 8x50G
+
+Maximum 50G ports - 128<br>
+*Other QSFP-DD breakout combinations are available up to maximum of 128x50G ports.
+{{< /tab >}}
+{{< tab "100G ">}}
+- 128x100G - 32xQSFP-DD breakout into 4x100G
+
+Maximum 100G ports - 128
+{{< /tab >}}
+{{< tab "200G ">}}
+- 64x200G - 64xQSFP-DD breakout into 2x200G
+
+Maximum 200G ports - 64
+{{< /tab >}}
+{{< tab "400G ">}}
+- 32x400G - 32xQSFP-DD (native speed)
+
+Maximum 400G ports - 32
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+<!-- SN4800 PLATFORM IS PLANNED TO NOV21 (CL5.0?)
+
+{{< tab "SN4800">}}
+SN4800 is a modular chassis with up to 8 line-cards. Each line-card can have up to 16 MAC addresses. Thus, each can be of a different port form-factor and speed.<br> 
+All line-cards supports both NRZ and PAM4 encodings with speeds down to 1G. For lower speeds, PAM4 automatically converted to NRZ encoding.<br>
+{{< tabs "4800_ports ">}}
+{{< tab "10G ">}}
+- 128x10G - 8 line-cards of 16xQSFP28* breakout into 4x25G and set to 10G
+
+Maximum 10G ports - 128<br>
+*Other combinations are possible by using higher-speed line-card with breakouts (up to 128x10G ports).
+{{< /tab >}}
+{{< tab "25G ">}}
+- 128x25G - 8 line-cards of 16xQSFP28* breakout into 4x25G
+
+Maximum 25G ports - 128<br>
+*Other combinations are possible by using higher-speed line-card with breakouts (up to 128x25G ports). 
+{{< /tab >}}
+{{< tab "40G ">}}
+- 128x40G - 8 line-cards of 16xQSFP28 set to 40G
+
+Maximum 40G ports - 128
+{{< /tab >}}
+{{< tab "50G ">}}
+- 128x50G - 8 line-cards of 8xQSFP56* breakout into 4x50G
+
+Maximum 50G ports - 128<br>
+*Other combinations are possible by using higher-speed line-card with breakouts (up to 128x50G ports). 
+{{< /tab >}}
+{{< tab "100G ">}}
+- 128x100G - 8 line-cards of 16xQSFP28* (native speed)
+
+Maximum 100G ports - 128<br>
+*Other combinations are possible by using higher-speed line-card with breakouts (up to 128x100G ports). 
+{{< /tab >}}
+{{< tab "200G ">}}
+- 64x200G - 8 line-cards of 8xQSFP56* (native speed)
+
+Maximum 200G ports - 64<br>
+*Other combinations arepossible by using higher-speed line-card with breakouts (up to 64x200G ports). 
+{{< /tab >}}
+{{< tab "400G ">}}
+- 32x400G - 8 line-cards of 4xQSFP-DD (native speed)
+
+Maximum 400G ports - 32
+{{< /tab >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+-->
+
+{{< /tabs >}}
 
 {{%notice note%}}
 - If you break out a port, then reload the `switchd` service on a switch running in *nonatomic* ACL mode, temporary disruption to traffic occurs while the ACLs are reinstalled.


### PR DESCRIPTION
added breakout information per platform.

FOR CL4.4 NEED TO REMOVE THE COMMENTED PLATFORMS (SN3510, SN4410, SN4600 AND SN4800). 
WE WILL ADD THEM TO FUTURE CUMULUS RELEASE/S