### PR TITLE
Update Installing-a-New-Cumulus-Linux-Image.md

### DIFF
--- a/content/cumulus-linux-42/Installation-Management/Installing-a-New-Cumulus-Linux-Image.md
+++ b/content/cumulus-linux-42/Installation-Management/Installing-a-New-Cumulus-Linux-Image.md
@@ -617,6 +617,8 @@ The original file is now split, with the first 20 lines in `cumulus-linux-4.2.0-
 
 3. Use a text editor to change the variables in `cumulus-linux-4.2.0-bcm-amd64.bin.1`.
 
+    After changing any variables you will need to recalculate the sha256 hash and update the `CL_INSTALLER_PAYLOAD_SHA256` variable.
+
 4. Put the two pieces back together using `cat`:
 
 ```


### PR DESCRIPTION
When editing the .bin file to pre-seed variables, you must also recalculate the sha256 hash or the image is considered invalid when you install it.