### PR TITLE
Remove reboot key combo from GRUB from pw recovery

### DIFF
--- a/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
+++ b/content/cumulus-linux-37/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
@@ -56,9 +56,7 @@ Hit any key to stop autoboot:  2
 3.  Select **Cumulus Linux GNU/Linux, with Linux 4.1.0-cl-7-amd64
     (recovery mode)**.
 
-4.  Press ctrl-x to reboot.
-
-5.  After the system reboots, set a new **root** password. This is
+4.  After the system reboots, set a new **root** password. This is
     useful since the root user provides complete control over the
     switch, and providing a new password now helps in case the current
     password has been forgotten, which is a common problem.
@@ -78,7 +76,7 @@ You may want to take this opportunity to reset the password for the
        passwd: password updated successfully
     {{%/notice%}}
 
-6.  Sync the `/etc` directory using `btrfs`, then reboot the system:
+5.  Sync the `/etc` directory using `btrfs`, then reboot the system:
 
         root@switch:~# btrfs filesystem sync /etc
         root@switch:~# reboot -f

--- a/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
+++ b/content/cumulus-linux-40/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
@@ -46,8 +46,7 @@ Hit any key to stop autoboot:  2
     +----------------------------------------------------------------------------+  
     ```
 
-4. Press ctrl-d to reboot.
-5. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
+3. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
 
     ```
     root@switch:~# passwd
@@ -65,7 +64,7 @@ Hit any key to stop autoboot:  2
     passwd: password updated successfully
     ```
 
-6. Sync the `/etc` directory, then reboot the system:
+4. Sync the `/etc` directory, then reboot the system:
 
     ```
     root@switch:~# sync

--- a/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
+++ b/content/cumulus-linux-41/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
@@ -42,8 +42,7 @@ Hit any key to stop autoboot:  2
        |                                                                            |
        +----------------------------------------------------------------------------+  
 
-4. Press ctrl-d to reboot.
-5. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
+3. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
 
        root@switch:~# passwd
        Enter new UNIX password:
@@ -61,7 +60,7 @@ You can take this opportunity to reset the password for the *cumulus* account.
 
 {{%/notice%}}
 
-6. Sync the `/etc` directory, then reboot the system:
+4. Sync the `/etc` directory, then reboot the system:
 
        root@switch:~# sync
        root@switch:~# reboot -f

--- a/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
+++ b/content/cumulus-linux-42/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
@@ -42,8 +42,7 @@ Hit any key to stop autoboot:  2
        |                                                                            |
        +----------------------------------------------------------------------------+  
 
-4. Press **ctrl-d** to reboot.
-5. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
+3. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
 
        root@switch:~# passwd
        Enter new UNIX password:
@@ -61,7 +60,7 @@ You can take this opportunity to reset the password for the *cumulus* account.
 
 {{%/notice%}}
 
-6. Sync the `/etc` directory, then reboot the system:
+4. Sync the `/etc` directory, then reboot the system:
 
        root@switch:~# sync
        root@switch:~# reboot -f

--- a/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
+++ b/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
@@ -42,8 +42,7 @@ Hit any key to stop autoboot:  2
        |                                                                            |
        +----------------------------------------------------------------------------+  
 
-4. Press **ctrl-d** to reboot.
-5. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
+3. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
 
        root@switch:~# passwd
        Enter new UNIX password:
@@ -61,7 +60,7 @@ You can take this opportunity to reset the password for the *cumulus* account.
 
 {{%/notice%}}
 
-6. Sync the `/etc` directory, then reboot the system:
+4. Sync the `/etc` directory, then reboot the system:
 
        root@switch:~# sync
        root@switch:~# reboot -f

--- a/content/cumulus-linux-44/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
+++ b/content/cumulus-linux-44/Monitoring-and-Troubleshooting/Single-User-Mode-Password-Recovery.md
@@ -41,8 +41,7 @@ Hit any key to stop autoboot:  2
        |                                                                            |
        +----------------------------------------------------------------------------+  
 
-4. Press **ctrl-d** to reboot.
-5. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
+3. After the system reboots, set a new **root** password. The root user provides complete control over the switch.
 
        root@switch:~# passwd
        Enter new UNIX password:
@@ -60,7 +59,7 @@ You can take this opportunity to reset the password for the *cumulus* account.
 
 {{%/notice%}}
 
-6. Sync the `/etc` directory, then reboot the system:
+4. Sync the `/etc` directory, then reboot the system:
 
        root@switch:~# sync
        root@switch:~# reboot -f


### PR DESCRIPTION
Removes mentions of Ctrl-X/Ctrl-D from
Single-User-Mode-Password-Recovery.md across all CL versions.
This is not needed because selecting Advanced options -> recovery mode
triggers a reboot on its own.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>