### PR TITLE
4.3: Move MH uplinks to Requred Config

### DIFF
--- a/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -105,6 +105,7 @@ To configure EVPN-MH, first you need to enable the `evpn.multihoming.enable` var
 
 - The Ethernet segment ID (`es-id`)
 - The Ethernet segment system MAC address (`es-sys-mac`)
+- MH Uplinks (`evpn mh uplink`)
 
 These settings are applied to interfaces, typically bonds.
 
@@ -232,6 +233,83 @@ interface hostbond3
 !
 ```
 
+### Enable Uplink Tracking
+
+When all the uplinks go down, the VTEP loses connectivity to the VXLAN overlay. To prevent traffic loss in this state, the uplinks' oper-state is tracked. When all the uplinks are down, the Ethernet segment bonds on the switch are put into a protodown or error-disabled state. An MH uplink is any routed interface where locally-encapsulated VXLAN traffic will be routed (after encapsulation) or any routed interface receiving VXLAN traffic (before decapsulation) that will be decapsulated by the local device.
+{{%notice info%}}
+Split-horizon and Designated-Forwarder filters are only applied to interfaces that have been configured as MH uplinks.
+If EVPN-MH is configured without MH uplinks BUM traffic may be duplicated and/or looped back to the same ES where it was received. This may cause 'mac flaps' or other issues on multihomed devices.
+{{%/notice%}}
+
+{{<tabs "upink tracking">}}
+
+{{<tab "NCLU Commands">}}
+
+    cumulus@switch:~$ net add interface swp1-4 evpn mh uplink
+    cumulus@switch:~$ net add interface swp1-4 pim
+    cumulus@switch:~$ net commit
+
+{{</tab>}}
+
+{{<tab "vtysh Commands">}}
+
+```
+cumulus@leaf01:~$ sudo vtysh
+
+Hello, this is FRRouting (version 7.4+cl4u1).
+Copyright 1996-2005 Kunihiro Ishiguro, et al.
+
+leaf01# configure terminal
+leaf01(config)# interface swp1
+leaf01(config-if)# evpn mh uplink
+leaf01(config-if)# ip pim
+leaf01(config-if)# exit
+leaf01(config)# interface swp2
+leaf01(config-if)# evpn mh uplink
+leaf01(config-if)# ip pim
+leaf01(config-if)# exit
+leaf01(config)# interface swp3
+leaf01(config-if)# evpn mh uplink
+leaf01(config-if)# ip pim
+leaf01(config-if)# exit
+leaf01(config)# interface swp4
+leaf01(config-if)# evpn mh uplink
+leaf01(config-if)# ip pim
+leaf01(config-if)# exit
+leaf01(config)# write memory
+leaf01(config)# exit
+leaf01# exit
+cumulus@leaf01:~$
+```
+
+{{</tab>}}
+
+{{</tabs>}}
+
+These commands create the following configuration in the `/etc/frr/frr.conf` file:
+
+```
+...
+!
+interface swp1
+ evpn mh uplink
+ ip pim
+!
+interface swp2
+ evpn mh uplink
+ ip pim
+!
+interface swp3
+ evpn mh uplink
+ ip pim
+!
+interface swp4
+ evpn mh uplink
+ ip pim
+!
+...
+```
+
 ### EVPN MH Global Settings
 
 There are a few global settings for EVPN multihoming you can set, including:
@@ -334,78 +412,6 @@ This creates the following configuration in the `/etc/frr/frr.conf` file:
 evpn mh startup-delay 1800
 ```
 
-### Enable Uplink Tracking
-
-When all the uplinks go down, the VTEP loses connectivity to the VXLAN overlay. To prevent traffic loss in this state, the uplinks' oper-state is tracked. When all the uplinks are down, the Ethernet segment bonds on the switch are put into a protodown or error-disabled state. You can configure a link as an MH uplink to enable this tracking.
-
-{{<tabs "upink tracking">}}
-
-{{<tab "NCLU Commands">}}
-
-    cumulus@switch:~$ net add interface swp1-4 evpn mh uplink
-    cumulus@switch:~$ net add interface swp1-4 pim
-    cumulus@switch:~$ net commit
-
-{{</tab>}}
-
-{{<tab "vtysh Commands">}}
-
-```
-cumulus@leaf01:~$ sudo vtysh
-
-Hello, this is FRRouting (version 7.4+cl4u1).
-Copyright 1996-2005 Kunihiro Ishiguro, et al.
-
-leaf01# configure terminal
-leaf01(config)# interface swp1
-leaf01(config-if)# evpn mh uplink
-leaf01(config-if)# ip pim
-leaf01(config-if)# exit
-leaf01(config)# interface swp2
-leaf01(config-if)# evpn mh uplink
-leaf01(config-if)# ip pim
-leaf01(config-if)# exit
-leaf01(config)# interface swp3
-leaf01(config-if)# evpn mh uplink
-leaf01(config-if)# ip pim
-leaf01(config-if)# exit
-leaf01(config)# interface swp4
-leaf01(config-if)# evpn mh uplink
-leaf01(config-if)# ip pim
-leaf01(config-if)# exit
-leaf01(config)# write memory
-leaf01(config)# exit
-leaf01# exit
-cumulus@leaf01:~$
-```
-
-{{</tab>}}
-
-{{</tabs>}}
-
-These commands create the following configuration in the `/etc/frr/frr.conf` file:
-
-```
-...
-!
-interface swp1
- evpn mh uplink
- ip pim
-!
-interface swp2
- evpn mh uplink
- ip pim
-!
-interface swp3
- evpn mh uplink
- ip pim
-!
-interface swp4
- evpn mh uplink
- ip pim
-!
-...
-```
 
 ### Enable FRR Debugging
 


### PR DESCRIPTION
In CL 4.3.0.1 and 4.4.0, EVPN-MH Uplinks must be configured in order for
SPH/DF filters to be programmed properly.
Updates the docs to reflect this and adds a note indicating what might occur
when the required config is not present.