### PR TITLE
Fix typo in Validation-Checks.md

### DIFF
--- a/content/cumulus-netq-40/Validate-Operations/Validation-Checks.md
+++ b/content/cumulus-netq-40/Validate-Operations/Validation-Checks.md
@@ -100,7 +100,7 @@ The NTP validation test looks for poor operational status of the NTP service. Th
 
 ## OSPF Validation Tests
 
-The EVPN validation tests look for indications of the service health and configuration consistency. This is accomplished with the following tests:
+The OSPF validation tests look for indications of the service health and configuration consistency. This is accomplished with the following tests:
 
 | Test Number | Test Name | Description |
 | :---------: | --------- | ----------- |


### PR DESCRIPTION
The OSPF Validation Tests description incorrectly mentioned
"EVPN validation tests".  Fix typo to properly say "OSPF validation
tests".