### PR TITLE
System-Configuration: Add command to disable API

### DIFF
--- a/content/cumulus-linux-36/System-Configuration/HTTP-API.md
+++ b/content/cumulus-linux-36/System-Configuration/HTTP-API.md
@@ -56,6 +56,11 @@ the HTTP API service:
     cumulus@switch:~$ sudo systemctl start restserver
     cumulus@switch:~$ sudo systemctl stop restserver
 
+Use the `systemctl disable` command to disable the HTTP API service
+from running at startup:
+
+    cumulus@switch:~$ sudo systemctl disable restserver
+
 {{%notice note%}}
 
 Each service runs as a background daemon once started.

--- a/content/cumulus-linux-37/System-Configuration/HTTP-API.md
+++ b/content/cumulus-linux-37/System-Configuration/HTTP-API.md
@@ -46,6 +46,11 @@ the HTTP API service:
     cumulus@switch:~$ sudo systemctl start restserver
     cumulus@switch:~$ sudo systemctl stop restserver
 
+Use the `systemctl disable` command to disable the HTTP API service
+from running at startup:
+
+    cumulus@switch:~$ sudo systemctl disable restserver
+
 {{%notice note%}}
 
 Each service runs as a background daemon once started.

--- a/content/cumulus-linux-40/System-Configuration/HTTP-API.md
+++ b/content/cumulus-linux-40/System-Configuration/HTTP-API.md
@@ -23,6 +23,12 @@ cumulus@switch:~$ sudo systemctl start restserver
 cumulus@switch:~$ sudo systemctl stop restserver
 ```
 
+Use the `systemctl disable` command to disable the HTTP API service from running at startup:
+
+```
+cumulus@switch:~$ sudo systemctl disable restserver
+```
+
 {{%notice note%}}
 
 Each service runs as a background daemon.

--- a/content/cumulus-linux-41/System-Configuration/HTTP-API.md
+++ b/content/cumulus-linux-41/System-Configuration/HTTP-API.md
@@ -29,6 +29,12 @@ cumulus@switch:~$ sudo systemctl start restserver
 cumulus@switch:~$ sudo systemctl stop restserver
 ```
 
+Use the `systemctl disable` command to disable the service from running at startup:
+
+```
+cumulus@switch:~$ sudo systemctl disable restserver
+```
+
 {{%notice note%}}
 
 Each service runs as a background daemon.

--- a/content/cumulus-linux-42/System-Configuration/HTTP-API.md
+++ b/content/cumulus-linux-42/System-Configuration/HTTP-API.md
@@ -29,6 +29,12 @@ cumulus@switch:~$ sudo systemctl start restserver
 cumulus@switch:~$ sudo systemctl stop restserver
 ```
 
+Use the `systemctl disable` command to disable the service from running at startup:
+
+```
+cumulus@switch:~$ sudo systemctl disable restserver
+```
+
 Each service runs as a background daemon.
 
 ## Configure API Services

--- a/content/cumulus-linux-43/System-Configuration/HTTP-API.md
+++ b/content/cumulus-linux-43/System-Configuration/HTTP-API.md
@@ -29,6 +29,12 @@ cumulus@switch:~$ sudo systemctl start restserver
 cumulus@switch:~$ sudo systemctl stop restserver
 ```
 
+Use the `systemctl disable` command to disable the service from running at startup:
+
+```
+cumulus@switch:~$ sudo systemctl disable restserver
+```
+
 Each service runs as a background daemon.
 
 ## Configure API Services


### PR DESCRIPTION
The existing docs did not have any references to disabling the nginx
or restserver services on the switch.
Added items for using 'systemctl disable' to ensure the services
don't start when the system boots up.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>