### PR TITLE
Vale tweaks

### DIFF
--- a/utils/.vale/styles/write-good/Passive.yml
+++ b/utils/.vale/styles/write-good/Passive.yml
@@ -112,7 +112,6 @@ tokens:
   - sawn
   - seen
   - sent
-  - set
   - sewn
   - shaken
   - shaven

--- a/utils/.vale/styles/write-good/TooWordy.yml
+++ b/utils/.vale/styles/write-good/TooWordy.yml
@@ -59,7 +59,6 @@ tokens:
   - consequently
   - consolidate
   - constitutes
-  - demonstrate
   - depart
   - designate
   - discontinue


### PR DESCRIPTION
Ticket:
Reviewed By:
Testing Done:

"demonstrate" is a perfectly cromulent word in context. Also, removed "set" from the list of passive words, since "is set" is a very common construction in tech writing.