### PR TITLE
Air: Add secureboot to What's New

### DIFF
--- a/content/guides/nvidia-air/Continuous-Integration.md
+++ b/content/guides/nvidia-air/Continuous-Integration.md
@@ -3,6 +3,7 @@ title: Continuous Integration
 author: NVIDIA
 weight: 50
 version: "1.0"
+product: NVIDIA Air
 ---
 
 NVIDIA Air supports the ability to integrate a Network Continuous Integration (NetCI) pipeline. It provides workflows to onboard production code and have it tested against a digital simulation of the network.

--- a/content/guides/nvidia-air/Custom-Topology.md
+++ b/content/guides/nvidia-air/Custom-Topology.md
@@ -3,6 +3,7 @@ title: Custom Topology
 author: NVIDIA
 weight: 40
 version: "1.0"
+product: NVIDIA Air
 ---
 
 NVIDIA Air fully supports the creation of custom topologies. This feature augments the pre-built demo infrastructure.

--- a/content/guides/nvidia-air/Pre-Built-Demos.md
+++ b/content/guides/nvidia-air/Pre-Built-Demos.md
@@ -3,6 +3,7 @@ title: Pre-built Demos
 author: NVIDIA
 weight: 30
 version: "1.0"
+product: NVIDIA Air
 ---
 
 Three demos are available in the Air simulation:

--- a/content/guides/nvidia-air/Quick-Start.md
+++ b/content/guides/nvidia-air/Quick-Start.md
@@ -3,6 +3,7 @@ title: Quick Start
 author: NVIDIA
 weight: 20
 version: "1.0"
+product: NVIDIA Air
 ---
 
 This quick start provides an easy way to get started with the NVIDIA Air simulation platform.

--- a/content/guides/nvidia-air/Whats-New.md
+++ b/content/guides/nvidia-air/Whats-New.md
@@ -3,13 +3,20 @@ title: What's New in NVIDIA Air
 author: NVIDIA
 weight: 20
 version: "1.0"
+product: NVIDIA Air
 ---
 
 Check out some of the latest features added to the {{<exlink url="https://air.nvidia.com" text="NVIDIA Air Infrastructure Simulation Platform">}}.
 
+<!-- Air:WhatsNew -->
 ## September 2021
 <!-- vale off -->
-<!-- Air:WhatsNew -->
+- Enable UEFI SecureBoot for virtual machines using the `secureboot` option in your DOT file. For example:
+
+```
+"server" [function="server" os="generic/ubuntu2004" secureboot="true"]
+```
+
 - {{<exlink url="https://air.nvidia.com/marketplace" text="Demo Marketplace">}}: Get a jump start on your network configuration by checking out some pre-built feature demos, or submit your own!
 <!-- Air:WhatsNew -->
 - This page! Be sure to check back often to see the latest features we're adding to NVIDIA Air.

--- a/content/guides/nvidia-air/Whats-New.md
+++ b/content/guides/nvidia-air/Whats-New.md
@@ -8,9 +8,9 @@ product: NVIDIA Air
 
 Check out some of the latest features added to the {{<exlink url="https://air.nvidia.com" text="NVIDIA Air Infrastructure Simulation Platform">}}.
 
-<!-- Air:WhatsNew -->
 ## September 2021
 <!-- vale off -->
+<!-- Air:WhatsNew -->
 - Enable UEFI SecureBoot for virtual machines using the `secureboot` option in your DOT file. For example:
 
 ```


### PR DESCRIPTION
Adds the new SecureBoot option to the What's New announcement.

Also adds a "Product" attribute to the Air pages to remove the `<nil>` that shows up in the title. 