### PR TITLE
Network-Virtualization: Add 'match evpn vni' to docs

### DIFF
--- a/content/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN.md
+++ b/content/cumulus-linux-36/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN.md
@@ -1075,6 +1075,22 @@ only:
     cumulus@switch:~$ net pending
     cumulus@switch:~$ net commit
 
+### Filtering EVPN Routes Based on VNI
+
+In many situations, it is desirable to only exchange EVPN routes carrying
+a particular VXLAN ID. For example, if only certain tenants are shared
+across data centers, or across pods within a data center, a route-map
+may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes
+with a particular VNI to be advertised in the fabric, use these commands:
+
+    net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ## EVPN Operational Commands
 
 ### General Linux Commands Related to EVPN

--- a/content/cumulus-linux-37/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN.md
+++ b/content/cumulus-linux-37/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN.md
@@ -1119,6 +1119,22 @@ only:
     cumulus@switch:~$ net pending
     cumulus@switch:~$ net commit
 
+### Filtering EVPN Routes Based on VNI
+
+In many situations, it is desirable to only exchange EVPN routes carrying
+a particular VXLAN ID. For example, if only certain tenants are shared
+across data centers, or across pods within a data center, a route-map
+may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes
+with a particular VNI to be advertised in the fabric, use these commands:
+
+    net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ### Advertise SVI IP Addresses
 
 In a typical EVPN deployment, you *reuse* SVI IP addresses on VTEPs

--- a/content/cumulus-linux-40/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-40/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -471,6 +471,51 @@ cumulus@switch:~$
 
 {{< /tabs >}}
 
+In many situations, it is also desirable to only exchange EVPN routes carrying a particular VXLAN ID.
+For example, if only certain tenants are shared across data centers, or across pods within a data center, a route-map may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes with a particular VNI to be advertised in the fabric:
+
+{{< tabs "TabID44" >}}
+
+{{< tab "NCLU Commands" >}}
+
+Use the `net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>` command.
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ net add routing route-map map1 permit 1 match evpn vni 1000
+cumulus@switch:~$ net pending
+cumulus@switch:~$ net commit
+```
+
+{{< /tab >}}
+
+{{< tab "vtysh Commands" >}}
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ sudo vtysh
+
+switch# configure terminal
+switch(config)# route-map map1 permit 1
+switch(config)# match evpn vni 1000
+switch(config)# end
+switch# write memory
+switch# exit
+cumulus@switch:~$
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ## Advertise SVI IP Addresses
 
 In a typical EVPN deployment, you *reuse* SVI IP addresses on VTEPs across multiple racks. However, if you use *unique* SVI IP addresses across multiple racks and you want the local SVI IP address to be reachable via remote VTEPs, you can enable the `advertise-svi-ip` option. This option advertises the SVI IP/MAC address as a type-2 route and eliminates the need for any flooding over VXLAN to reach the IP from a remote VTEP/rack.

--- a/content/cumulus-linux-41/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-41/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -477,6 +477,51 @@ cumulus@switch:~$
 
 {{< /tabs >}}
 
+In many situations, it is also desirable to only exchange EVPN routes carrying a particular VXLAN ID.
+For example, if only certain tenants are shared across data centers, or across pods within a data center, a route-map may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes with a particular VNI to be advertised in the fabric:
+
+{{< tabs "TabID44" >}}
+
+{{< tab "NCLU Commands" >}}
+
+Use the `net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>` command.
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ net add routing route-map map1 permit 1 match evpn vni 1000
+cumulus@switch:~$ net pending
+cumulus@switch:~$ net commit
+```
+
+{{< /tab >}}
+
+{{< tab "vtysh Commands" >}}
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ sudo vtysh
+
+switch# configure terminal
+switch(config)# route-map map1 permit 1
+switch(config)# match evpn vni 1000
+switch(config)# end
+switch# write memory
+switch# exit
+cumulus@switch:~$
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ## Advertise SVI IP Addresses
 
 In a typical EVPN deployment, you *reuse* SVI IP addresses on VTEPs across multiple racks. However, if you use *unique* SVI IP addresses across multiple racks and you want the local SVI IP address to be reachable via remote VTEPs, you can enable the `advertise-svi-ip` option. This option advertises the SVI IP/MAC address as a type-2 route and eliminates the need for any flooding over VXLAN to reach the IP from a remote VTEP/rack.

--- a/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-42/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -651,6 +651,52 @@ cumulus@leaf01:~$
 You must apply the route map for the configuration to take effect. See {{<link url="Route-Filtering-and-Redistribution/#route-maps" text="Route Maps">}} for more information.
 {{%/notice%}}
 
+
+In many situations, it is also desirable to only exchange EVPN routes carrying a particular VXLAN ID.
+For example, if only certain tenants are shared across data centers, or across pods within a data center, a route-map may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes with a particular VNI to be advertised in the fabric:
+
+{{< tabs "TabID44" >}}
+
+{{< tab "NCLU Commands" >}}
+
+Use the `net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>` command.
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ net add routing route-map map1 permit 1 match evpn vni 1000
+cumulus@switch:~$ net pending
+cumulus@switch:~$ net commit
+```
+
+{{< /tab >}}
+
+{{< tab "vtysh Commands" >}}
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ sudo vtysh
+
+switch# configure terminal
+switch(config)# route-map map1 permit 1
+switch(config)# match evpn vni 1000
+switch(config)# end
+switch# write memory
+switch# exit
+cumulus@switch:~$
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ## Advertise SVI IP Addresses
 
 In a typical EVPN deployment, you *reuse* SVI IP addresses on VTEPs across multiple racks. However, if you use *unique* SVI IP addresses across multiple racks and you want the local SVI IP address to be reachable via remote VTEPs, you can enable the `advertise-svi-ip` option. This option advertises the SVI IP/MAC address as a type-2 route and eliminates the need for any flooding over VXLAN to reach the IP from a remote VTEP/rack.

--- a/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-43/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -739,6 +739,51 @@ cumulus@leaf01:~$
 You must apply the route map for the configuration to take effect. See {{<link url="Route-Filtering-and-Redistribution/#route-maps" text="Route Maps">}} for more information.
 {{%/notice%}}
 
+In many situations, it is also desirable to only exchange EVPN routes carrying a particular VXLAN ID.
+For example, if only certain tenants are shared across data centers, or across pods within a data center, a route-map may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes with a particular VNI to be advertised in the fabric:
+
+{{< tabs "TabID44" >}}
+
+{{< tab "NCLU Commands" >}}
+
+Use the `net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>` command.
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ net add routing route-map map1 permit 1 match evpn vni 1000
+cumulus@switch:~$ net pending
+cumulus@switch:~$ net commit
+```
+
+{{< /tab >}}
+
+{{< tab "vtysh Commands" >}}
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ sudo vtysh
+
+switch# configure terminal
+switch(config)# route-map map1 permit 1
+switch(config)# match evpn vni 1000
+switch(config)# end
+switch# write memory
+switch# exit
+cumulus@switch:~$
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ## Advertise SVI IP Addresses
 
 In a typical EVPN deployment, you *reuse* SVI IP addresses on VTEPs across multiple racks. However, if you use *unique* SVI IP addresses across multiple racks and you want the local SVI IP address to be reachable via remote VTEPs, you can enable the `advertise-svi-ip` option. This option advertises the SVI IP/MAC address as a type-2 route and eliminates the need for any flooding over VXLAN to reach the IP from a remote VTEP/rack.

--- a/content/cumulus-linux-44/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-44/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -879,6 +879,51 @@ cumulus@leaf01:~$
 You must apply the route map for the configuration to take effect. See {{<link url="Route-Filtering-and-Redistribution/#route-maps" text="Route Maps">}} for more information.
 {{%/notice%}}
 
+In many situations, it is also desirable to only exchange EVPN routes carrying a particular VXLAN ID.
+For example, if only certain tenants are shared across data centers, or across pods within a data center, a route-map may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes with a particular VNI to be advertised in the fabric:
+
+{{< tabs "TabID44" >}}
+
+{{< tab "NCLU Commands" >}}
+
+Use the `net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>` command.
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ net add routing route-map map1 permit 1 match evpn vni 1000
+cumulus@switch:~$ net pending
+cumulus@switch:~$ net commit
+```
+
+{{< /tab >}}
+
+{{< tab "vtysh Commands" >}}
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ sudo vtysh
+
+switch# configure terminal
+switch(config)# route-map map1 permit 1
+switch(config)# match evpn vni 1000
+switch(config)# end
+switch# write memory
+switch# exit
+cumulus@switch:~$
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ## Advertise SVI IP Addresses
 
 In a typical EVPN deployment, you *reuse* SVI IP addresses on VTEPs across multiple racks. However, if you use *unique* SVI IP addresses across multiple racks and you want the local SVI IP address to be reachable via remote VTEPs, you can enable the advertise SVI IP/MAC address option. This option advertises the SVI IP/MAC address as a type-2 route and eliminates the need for any flooding over VXLAN to reach the IP address from a remote VTEP or rack.

--- a/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -879,6 +879,51 @@ cumulus@leaf01:~$
 You must apply the route map for the configuration to take effect. See {{<link url="Route-Filtering-and-Redistribution/#route-maps" text="Route Maps">}} for more information.
 {{%/notice%}}
 
+In many situations, it is also desirable to only exchange EVPN routes carrying a particular VXLAN ID.
+For example, if only certain tenants are shared across data centers, or across pods within a data center, a route-map may be used to control which EVPN routes are exchanged based on the VNI.
+
+To filter EVPN routes based on the VXLAN ID and allow only EVPN routes with a particular VNI to be advertised in the fabric:
+
+{{< tabs "TabID44" >}}
+
+{{< tab "NCLU Commands" >}}
+
+Use the `net add routing route-map <route_map_name> (deny|permit) <1-65535> match evpn vni <1-16777215>` command.
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ net add routing route-map map1 permit 1 match evpn vni 1000
+cumulus@switch:~$ net pending
+cumulus@switch:~$ net commit
+```
+
+{{< /tab >}}
+
+{{< tab "vtysh Commands" >}}
+
+The following example configures a route-map that only advertises EVPN routes from VNI 1000:
+
+```
+cumulus@switch:~$ sudo vtysh
+
+switch# configure terminal
+switch(config)# route-map map1 permit 1
+switch(config)# match evpn vni 1000
+switch(config)# end
+switch# write memory
+switch# exit
+cumulus@switch:~$
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+{{%notice note%}}
+Only type-2 and type-5 can be matched based on VNI. All other EVPN route-types will not be matched by the route-map.
+{{%/notice%}}
+
 ## Advertise SVI IP Addresses
 
 In a typical EVPN deployment, you *reuse* SVI IP addresses on VTEPs across multiple racks. However, if you use *unique* SVI IP addresses across multiple racks and you want the local SVI IP address to be reachable via remote VTEPs, you can enable the advertise SVI IP and MAC address option. This option advertises the SVI IP and MAC address as a type-2 route and eliminates the need for any flooding over VXLAN to reach the IP address from a remote VTEP or rack.


### PR DESCRIPTION
'match evpn vni' command was not documented prior to this.
Add it to the docs along with the caveat stating it only works
with type-2 and type-5 routes.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>