### PR TITLE
Update NVIDIA-User-Experience-NVUE.md

### DIFF
--- a/content/cumulus-linux-44/System-Configuration/NVIDIA-User-Experience-NVUE.md
+++ b/content/cumulus-linux-44/System-Configuration/NVIDIA-User-Experience-NVUE.md
@@ -83,6 +83,10 @@ To make a configuration change with the NVUE API:
 
    ```
 
+{{%notice note%}}
+If you have not already changed the cumulus user's default password, user cumulus will not be authorized to access the API.
+{{%/notice%}}
+
 2. Record the revision ID. In the above example, the revision ID is `"changeset/cumulus/2021-11-02_16.09.18_5Z1K"`.
 
 3. Make the change using a PATCH and link it to the revision ID:


### PR DESCRIPTION
If you have not already changed the cumulus user's default password, user cumulus will not be authorized to access the API. Authorization will fail with "401 Authorization Required" instead of a more explicit error message.