### PR TITLE
L3-Interface must exist for ARP suppression to work

### DIFF
--- a/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -446,6 +446,8 @@ ARP suppression with EVPN allows a VTEP to suppress ARP flooding over VXLAN tunn
 
 Cumulus Linux enables ARP and ND suppression by default on all VNIs to reduce ARP and ND packet flooding over VXLAN tunnels.
 
+This functionality needs L3 interfaces (SVIs) to be provisioned by the operator in order to work.
+
 {{%notice note%}}
 ARP and ND suppression only suppresses the flooding of known hosts. To disable all flooding refer to the {{<link title="#Disable BUM Flooding" text="Disable BUM Flooding" >}} section.
 {{%/notice%}}

--- a/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
+++ b/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Enhancements.md
@@ -444,9 +444,7 @@ Router ospf
 
 ARP suppression with EVPN allows a VTEP to suppress ARP flooding over VXLAN tunnels as much as possible. A local proxy handles ARP requests from locally attached hosts for remote hosts. ARP suppression is for IPv4; ND suppression is for IPv6.
 
-Cumulus Linux enables ARP and ND suppression by default on all VNIs to reduce ARP and ND packet flooding over VXLAN tunnels.
-
-This functionality needs L3 interfaces (SVIs) to be provisioned by the operator in order to work.
+Cumulus Linux enables ARP and ND suppression by default on all VNIs to reduce ARP and ND packet flooding over VXLAN tunnels; however, you must to configure layer 3 interfaces (SVIs) for ARP and ND suppression to work with EVPN.
 
 {{%notice note%}}
 ARP and ND suppression only suppresses the flooding of known hosts. To disable all flooding refer to the {{<link title="#Disable BUM Flooding" text="Disable BUM Flooding" >}} section.


### PR DESCRIPTION
Add a blurb to note that the L3 interfaces must exist for arp suppression to work since we rely on the kernel/neigh tables to handle suppression for now.