### PR TITLE
Update _index.md

### DIFF
--- a/content/cumulus-linux-43/Monitoring-and-Troubleshooting/_index.md
+++ b/content/cumulus-linux-43/Monitoring-and-Troubleshooting/_index.md
@@ -235,7 +235,6 @@ By default, not all log messages are sent to a remote server. To send other log 
    {{%notice note%}}
 
 - For TCP-based syslog, use two @@ before the IP address *@@192.168.1.2:514*.
-- Running `syslog` over TCP places a burden on the switch to queue packets in the `syslog` buffer. This may cause detrimental effects if the remote `syslog` server becomes unavailable.
 - The numbering of the files in `/etc/rsyslog.d/` dictates how the rules are installed into `rsyslog.d`. Lower numbered rules are processed first, and `rsyslog` processing *terminates* with the `stop` keyword. For example, the `rsyslog` configuration for FRR is stored in the `45-frr.conf` file with an explicit `stop` at the bottom of the file. FRR messages are logged to the `/var/log/frr/frr.log` file on the local disk only (these messages are not sent to a remote server using the default configuration). To log FRR messages remotely in addition to writing FRR messages to the local disk, rename the `99-syslog.conf` file to `11-remotesyslog.conf`. FRR messages are first processed by the `11-remotesyslog.conf` rule (transmit to remote server), then continue to be processed by the `45-frr.conf` file (write to local disk in the `/var/log/frr/frr.log` file).
 
 - Do not use the `imfile` module with any file written by `rsyslogd`.


### PR DESCRIPTION
Since the syslog over tcp doesn't cause any issues in CL 3.3.x and above (See RM # 2528354) comment #49 - there is no need for the note about syslog over tcp