### PR TITLE
Update EVPN-Multihoming.md

### DIFF
--- a/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
+++ b/content/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming.md
@@ -112,7 +112,18 @@ When you enable EVPN-MH, all SVI MAC addresses advertise as type-2 routes. You d
 cumulus@leaf01:~$ nv set evpn multihoming enable on
 cumulus@leaf01:~$ nv config apply
 ```
+Set the `evpn.multihoming.enable` variable in the `/etc/cumulus/switchd.conf` file to `TRUE`, then restart the `switchd` service. Cumulus Linux disables this variable by default.
 
+```
+cumulus@leaf01:~$ sudo nano /etc/cumulus/switchd.conf
+...
+evpn.multihoming.enable = TRUE
+...
+```
+
+```
+cumulus@leaf01:~$ sudo systemctl restart switchd.service
+```
 {{< /tab >}}
 {{< tab "Linux Commands ">}}
 


### PR DESCRIPTION
Currently NVUE command "nv set evpn multihoming enable on" doesn't activate MH in /etc/cumulus/switchd.conf. It's still needed to do it manually.
We already had few customers confused by UM description:
https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-50/Network-Virtualization/Ethernet-Virtual-Private-Network-EVPN/EVPN-Multihoming/#enable-evpn-mh

It's not clear that in addition to "nv set evpn multihoming enable on" need also to enable MH in /etc/cumulus/switchd.conf. It mentioned in the separate TAB.
Currently "nv set evpn multihoming enable on" has more informative role.
I have open RM to make it work via NVUE, so it will also enable MH in switchd.conf

For now, need to clarify in UM this point.