### PR TITLE
Update Protocol-Independent-Multicast-PIM.md

### DIFF
--- a/content/cumulus-linux-52/Layer-3/Protocol-Independent-Multicast-PIM.md
+++ b/content/cumulus-linux-52/Layer-3/Protocol-Independent-Multicast-PIM.md
@@ -248,7 +248,6 @@ spine01# exit
 {{< /tabs >}}
 
 {{%notice note%}}
-- You can either configure RP mappings for different multicast groups (as shown above) or use a prefix list to specify the RP to group mapping. You cannot use both methods at the same time.
 - NVIDIA recommends that you do not use a spine switch as an RP when using eBGP in a Clos network. See the [PIM Overview knowledge-base article]({{<ref "/knowledge-base/Configuration-and-Usage/Network-Configuration/PIM-Overview" >}}).
 - zebra does not resolve the next hop for the RP through the default route. To prevent multicast forwarding from failing, either provide a specific route to the RP or run the vtysh `ip nht resolve-via-default` configuration command to resolve the next hop for the RP through the default route.
 {{%/notice%}}


### PR DESCRIPTION
PIM RP can be configured with a prefix-list and with a group range. 
 
example:
ip pim rp 44.44.44.44 227.10.1.0/24
 
ip prefix-list DEMO premit 226.10.1.0/16
ip pim rp 66.66.66.66 prefix-list DEMO
 
Both the methods can be configured at the same time.