### PR TITLE
Fix Air API hyperlink

### DIFF
--- a/content/guides/nvidia-air/Air-Python-SDK.md
+++ b/content/guides/nvidia-air/Air-Python-SDK.md
@@ -6,7 +6,7 @@ weight: 999
 type: nojsscroll
 ---
 
-This project provides a Python SDK for interacting with the NVIDIA Air API (https://air.nvidia.com/api/).
+This project provides a Python SDK for interacting with the [NVIDIA Air API](https://air.nvidia.com/api/).
 
 ## SDK Usage
 ### Prerequisite for the SDK


### PR DESCRIPTION
The current link renders with a URL of `https://air.nvidia.com/api/)` for some reason, which doesn't load. Updating it to be a proper markdown link.