### PR TITLE
WJH: Disable default docker bridge

### DIFF
--- a/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Network-Troubleshooting/Mellanox-WJH.md
+++ b/content/cumulus-linux-43/Monitoring-and-Troubleshooting/Network-Troubleshooting/Mellanox-WJH.md
@@ -72,3 +72,19 @@ PCAP file path : /var/log/mellanox/wjh/wjh_user_2020_11_06_16_13_37.pcap
 2  20/11/06 16:13:31.063  -1     N/A    N/A   44:38:39:00:a4:80  44:38:39:00:a4:80  IPv4     N/A          N/A          N/A       L2     Error     Source MAC equals destination MAC - Bad packet
                                                                                                                                                   was received from peer
 ```
+
+## Considerations
+
+WJH runs in a Docker container. By default, when Docker starts, it creates a bridge called `docker0`. For compatibility reasons, you must disable the `docker0` bridge in the `/etc/docker/daemon.json` file.
+
+To disable the `docker0` bridge, add `"bridge": "none"` to the `/etc/docker/daemon.json` file, then start the WJH service:
+
+```
+root@switch:~# nano /etc/docker/daemon.json 
+{
+     "iptables": false,
+     "ip-forward": false,
+     "ip-masq": false,
+     "bridge": "none"
+}
+```

--- a/content/cumulus-linux-44/Monitoring-and-Troubleshooting/Network-Troubleshooting/Mellanox-WJH.md
+++ b/content/cumulus-linux-44/Monitoring-and-Troubleshooting/Network-Troubleshooting/Mellanox-WJH.md
@@ -74,15 +74,16 @@ PCAP file path : /var/log/mellanox/wjh/wjh_user_2021_06_16_12_03_15.pcap
 
 ## Considerations
 
-WJH runs in a Docker container. By default, when Docker starts, it creates a bridge called `docker0`. For compatibility reasons Cumulus Linux needs the `docker0` bridge to be disabled in the `/etc/docker/daemon.json` file. This can be disabled by adding `"bridge": "none"` to the json file and then starting the WJH service. 
-  
-The following example shows a configuration that disables the docker bridge: 
- ```
-root@switch:~# cat /etc/docker/daemon.json 
+WJH runs in a Docker container. By default, when Docker starts, it creates a bridge called `docker0`. For compatibility reasons, you must disable the `docker0` bridge in the `/etc/docker/daemon.json` file.
+
+To disable the `docker0` bridge, add `"bridge": "none"` to the `/etc/docker/daemon.json` file, then start the WJH service:
+
+```
+root@switch:~# nano /etc/docker/daemon.json 
 {
      "iptables": false,
      "ip-forward": false,
      "ip-masq": false,
      "bridge": "none"
 }
- ```
+```

--- a/content/cumulus-linux-44/Monitoring-and-Troubleshooting/Network-Troubleshooting/Mellanox-WJH.md
+++ b/content/cumulus-linux-44/Monitoring-and-Troubleshooting/Network-Troubleshooting/Mellanox-WJH.md
@@ -71,3 +71,18 @@ PCAP file path : /var/log/mellanox/wjh/wjh_user_2021_06_16_12_03_15.pcap
 3    21/06/16 12:03:12.745  swp1   N/A    N/A   44:38:39:00:a4:84  44:38:39:00:a4:84  IPv4     N/A          N/A          N/A       L2     Error     Source MAC equals destination MAC - Bad packet was received from peer
 4    21/06/16 12:03:12.745  swp1   N/A    N/A   44:38:39:00:a4:84  44:38:39:00:a4:84  IPv4     N/A          N/A          N/A       L2     Error     Source MAC equals destination MAC - Bad packet was received from peer
 ```
+
+## Considerations
+
+WJH runs in a Docker container. By default, when Docker starts, it creates a bridge called `docker0`. For compatibility reasons Cumulus Linux needs the `docker0` bridge to be disabled in the `/etc/docker/daemon.json` file. This can be disabled by adding `"bridge": "none"` to the json file and then starting the WJH service. 
+  
+The following example shows a configuration that disables the docker bridge: 
+ ```
+root@switch:~# cat /etc/docker/daemon.json 
+{
+     "iptables": false,
+     "ip-forward": false,
+     "ip-masq": false,
+     "bridge": "none"
+}
+ ```


### PR DESCRIPTION
In 4.x and earlier, we need to disable the default docker bridge or it can cause compatibility issues. 

Documented the configuration required to disable the bridge.