### PR TITLE
Update Using-sudo-to-Delegate-Privileges.md

### DIFF
--- a/content/cumulus-linux-53/System-Configuration/Authentication-Authorization-and-Accounting/Using-sudo-to-Delegate-Privileges.md
+++ b/content/cumulus-linux-53/System-Configuration/Authentication-Authorization-and-Accounting/Using-sudo-to-Delegate-Privileges.md
@@ -64,11 +64,11 @@ When an unprivileged user runs a command, the command must include the `sudo` pr
 | Netfilter | List iptables rules | iptables -L | %noc ALL=(ALL) NOPASSWD:/sbin/iptables |
 | Layer 1 and 2 |Any LLDP command | lldpcli show neighbors / configure | %noc ALL=(ALL) NOPASSWD:/usr/sbin/lldpcli |
 | Layer 1 and 2 | Just show neighbors | lldpcli show neighbors | %noc ALL=(ALL) NOPASSWD:/usr/sbin/lldpcli show neighbors* |
-| Interfaces | Modify any interface | ip link set dev swp1 {up|down} | %noc ALL=(ALL) NOPASSWD:/sbin/ip link set * |
+| Interfaces | Modify any interface | ip link set dev swp1 {up\|down} | %noc ALL=(ALL) NOPASSWD:/sbin/ip link set * |
 | Interfaces | Up any interface | ifup swp1 | %noc ALL=(ALL) NOPASSWD:/sbin/ifup |
 | Interfaces | Down any interface | ifdown swp1 | %noc ALL=(ALL) NOPASSWD:/sbin/ifdown |
 | Interfaces | Up/down only swp2 | ifup swp2 / ifdown swp2 | %noc ALL=(ALL) NOPASSWD:/sbin/ifup swp2,/sbin/ifdown swp2 |
-| Interfaces | Any IP address change | ip addr {add|del} 192.0.2.1/30 dev swp1 | %noc ALL=(ALL) NOPASSWD:/sbin/ip addr * |
+| Interfaces | Any IP address change | ip addr {add\|del} 192.0.2.1/30 dev swp1 | %noc ALL=(ALL) NOPASSWD:/sbin/ip addr * |
 | Interfaces | Only set IP address | ip addr add 192.0.2.1/30 dev swp1 | %noc ALL=(ALL) NOPASSWD:/sbin/ip addr add * |
 | Ethernet bridging | Any bridge command | brctl addbr br0 / brctl delif br0 swp1 | %noc ALL=(ALL) NOPASSWD:/sbin/brctl |
 | Ethernet bridging | Add bridges and interfaces | brctl addbr br0 / brctl addif br0 swp1 | %noc ALL=(ALL) NOPASSWD:/sbin/brctl addbr *,/sbin/brctl addif * |


### PR DESCRIPTION
Added a backslash ("\\") before the pipe ("|") in the following rows to prevent erroneous field splitting.
- Modify any interface	
- Any IP address change