### PR TITLE
nv config apply empty only resets the nvue config

### DIFF
--- a/content/cumulus-linux-56/System-Configuration/NVIDIA-User-Experience-NVUE/NVUE-CLI.md
+++ b/content/cumulus-linux-56/System-Configuration/NVIDIA-User-Experience-NVUE/NVUE-CLI.md
@@ -426,7 +426,7 @@ cumulus@switch:~$ nv config apply -m "this is my message"
 
 ## Clear Switch Configuration
 
-To reset the configuration on the switch back to the factory defaults, run the following command:
+To reset the NVUE configuration on the switch back to defaults, run the following command:
 
 ```
 cumulus@switch:~$ nv config apply empty


### PR DESCRIPTION
Factory defaults would require onie-install to accomplish. This command only resets the NVUE configuration.
Made more clear to make the command match expectations.