### PR TITLE
Update Interface.md

### DIFF
--- a/content/nvue-reference/Set-and-Unset-Commands/Interface.md
+++ b/content/nvue-reference/Set-and-Unset-Commands/Interface.md
@@ -870,7 +870,7 @@ Configures the loopback in the specified VRF.
 
 ## <h>nv set vrf \<vrf-id\> loopback ip address \<ip-prefix-id\></h>
 
-Configures the loopback IP address in the specified VRF.
+Configures the loopback IP address in the specified VRF. For VRF default use command "nv set interface lo ip add <ip-prefix-id>".
 
 ### Command Syntax
 
@@ -886,5 +886,5 @@ Introduced in Cumulus Linux 5.0.0
 ### Example
 
 ```
-cumulus@switch:~$ nv set vrf default loopback ip address 10.10.10.1/32
+cumulus@switch:~$ nv set vrf RED loopback ip address 10.10.10.1/32
 ```

--- a/content/nvue-reference/Set-and-Unset-Commands/Interface.md
+++ b/content/nvue-reference/Set-and-Unset-Commands/Interface.md
@@ -870,7 +870,11 @@ Configures the loopback in the specified VRF.
 
 ## <h>nv set vrf \<vrf-id\> loopback ip address \<ip-prefix-id\></h>
 
-Configures the loopback IP address in the specified VRF. For VRF default use command "nv set interface lo ip add <ip-prefix-id>".
+Configures the loopback IP address in the specified VRF.
+
+{{%notice note%}}
+For the default VRF, use the `nv set interface lo ip address <ip-prefix-id>` command.
+{{%/notice%}}
 
 ### Command Syntax
 


### PR DESCRIPTION
Customer case 00660779

A user tried to configure the loopback ip address with command "nv set vrf default loopback ip address 10.10.10.1/32" as per the NVUE command reference, which does not work (tested and verified in CL 5.7 lab box

Proposed to change the example from default to RED and add a note that the command is intended for non default vrf ip address assignment