### PR TITLE
Update Netfilter-ACLs.md

### DIFF
--- a/content/cumulus-linux-55/System-Configuration/Netfilter-ACLs.md
+++ b/content/cumulus-linux-55/System-Configuration/Netfilter-ACLs.md
@@ -790,6 +790,10 @@ You can configure control plane ACLs to apply a single rule for all packets forw
 
 Cumulus Linux applies inbound control plane ACLs in the INPUT chain and outbound control plane ACLs in the OUTPUT chain.
 
+{{%notice note%}}
+Cumulus Linux does not support a **deny all** control plane rule.  This type of rule blocks traffic for interprocess communication and impacts overall system functionality.
+{{%/notice%}}
+
 The following example command applies the input control plane ACL called ACL1.
 
 ```

--- a/content/cumulus-linux-56/System-Configuration/Netfilter-ACLs.md
+++ b/content/cumulus-linux-56/System-Configuration/Netfilter-ACLs.md
@@ -791,6 +791,10 @@ You can configure control plane ACLs to apply a single rule for all packets forw
 
 Cumulus Linux applies inbound control plane ACLs in the INPUT chain and outbound control plane ACLs in the OUTPUT chain.
 
+{{%notice note%}}
+Cumulus Linux does not support a **deny all** control plane rule.  This type of rule blocks traffic for interprocess communication and impacts overall system functionality.
+{{%/notice%}}
+
 The following example command applies the input control plane ACL called ACL1.
 
 ```

--- a/content/cumulus-linux-57/System-Configuration/Netfilter-ACLs.md
+++ b/content/cumulus-linux-57/System-Configuration/Netfilter-ACLs.md
@@ -792,7 +792,7 @@ You can configure control plane ACLs to apply a single rule for all packets forw
 Cumulus Linux applies inbound control plane ACLs in the INPUT chain and outbound control plane ACLs in the OUTPUT chain.
 
 {{%notice note%}}
-Cumulus Linux does not support a deny all control plane rule.  If applied this may lead to blocking of traffic required for interprocess communication and impact overall system functionality.
+Cumulus Linux does not support a **deny all** control plane rule.  This type of rule blocks traffic for interprocess communication and impacts overall system functionality.
 {{%/notice%}}
 
 The following example command applies the input control plane ACL called ACL1.

--- a/content/cumulus-linux-57/System-Configuration/Netfilter-ACLs.md
+++ b/content/cumulus-linux-57/System-Configuration/Netfilter-ACLs.md
@@ -791,6 +791,10 @@ You can configure control plane ACLs to apply a single rule for all packets forw
 
 Cumulus Linux applies inbound control plane ACLs in the INPUT chain and outbound control plane ACLs in the OUTPUT chain.
 
+{{%notice note%}}
+Cumulus Linux does not support a deny all control plane rule.  If applied this may lead to blocking of traffic required for interprocess communication and impact overall system functionality.
+{{%/notice%}}
+
 The following example command applies the input control plane ACL called ACL1.
 
 ```

--- a/content/cumulus-linux-58/System-Configuration/Netfilter-ACLs.md
+++ b/content/cumulus-linux-58/System-Configuration/Netfilter-ACLs.md
@@ -801,6 +801,10 @@ You can configure control plane ACLs to apply a single rule for all packets forw
 
 Cumulus Linux applies inbound control plane ACLs in the INPUT chain and outbound control plane ACLs in the OUTPUT chain.
 
+{{%notice note%}}
+Cumulus Linux does not support a **deny all** control plane rule.  This type of rule blocks traffic for interprocess communication and impacts overall system functionality.
+{{%/notice%}}
+
 The following example command applies the input control plane ACL called ACL1.
 
 ```


### PR DESCRIPTION
As found in 3767212 a deny all control plane rule will break interprocess communication required for switchd to function and possibly several other services.

We have a fix for adding new default rules to allow this as well as some additional cleanup items needed in code in nvue, cl-acltool and switchd to prevent the configuration of this type of acl or modifying of these new rules that are required for platform functionality.

However, until all of these asks are addressed we need to have some literature in our User Guide that will steer customers away from making this mistake and breaking their switches :(.