### PR TITLE
Update System-Power.md

### DIFF
--- a/content/cumulus-linux-511/System-Configuration/System-Power.md
+++ b/content/cumulus-linux-511/System-Configuration/System-Power.md
@@ -4,14 +4,14 @@ author: NVIDIA
 weight: 295
 toc: 3
 ---
-In certain situations, you might need to power off the switch instead of rebooting. To power off the switch, you can run the Linux `poweroff` command, which gracefully shuts down the switch (the switch LEDs stay on).
-
-```
-cumulus@switch:~$ sudo poweroff
-```
-
-When you run the Linux `poweroff` command on certain switches, such as the NVIDIA SN2201, SN2010, SN2100, SN2100B, SN3420, SN3700, SN3700C, SN4410, SN4600C, SN4600, SN4700, SN5400, or SN5600, the switch reboots instead of powering off. To power off the switch, run the `cl-poweroff` command instead.
+In certain situations, you might need to power off the switch instead of rebooting. To power off the switch, run the `cl-poweroff` command, which shuts down the switch.
 
 ```
 cumulus@switch:~$ sudo cl-poweroff
+```
+
+Alternatively, you can run the Linux `poweroff` command, which will gracefully shut down the switch (the switch LEDs stay on). On certain switches, such as the NVIDIA SN2201, SN2010, SN2100, SN2100B, SN3420, SN3700, SN3700C, SN4410, SN4600C, SN4600, SN4700, SN5400, or SN5600, the switch reboots instead of powering off
+
+```
+cumulus@switch:~$ sudo poweroff
 ```


### PR DESCRIPTION
Re-ordering these commands. Having a switch reboot and not power off when we intended to power off can cause service interruption. Probably better to remove the `sudo poweroff` command since it will reboot and NOT shutdown on almost every switch model