### PR TITLE
ZTP script info update

### DIFF
--- a/content/nvidia-air/Custom-Topology.md
+++ b/content/nvidia-air/Custom-Topology.md
@@ -25,7 +25,9 @@ One way to create fully custom simulations is with the built-in topology builder
 
 ### ZTP Scripts
 
-When you create a new simulation, Air gives you the option to add a zero-touch provisioning (ZTP) script. The ZTP script is copied to the simulation's `oob-mgmt-server`. Any node making a ZTP request on the out-of-band management network has access to this ZTP script through a DHCP server and web server running on the `oob-mgmt-server`.
+When you create a new simulation, Air gives you the option to add a zero-touch provisioning (ZTP) script. The ZTP script is copied to the simulation's `oob-mgmt-server`. Any node making a ZTP request on the out-of-band management network has access to this ZTP script through a DHCP server and web server running on the `oob-mgmt-server`. 
+
+**ZTP scripts will not be used if the simulation does not have OOB automatically configured.**
 
 A default script is prefilled to help you get started. It implements some common ZTP features on Cumulus Linux, such as changing the default password or downloading SSH keys. You can edit the default script directly in the UI.
 


### PR DESCRIPTION
We need to make it more clear that ZTP scripts cannot be used if automatic OOB configuration is not enabled.