### PR TITLE
Update LDAP-Authentication-and-Authorization.md

### DIFF
--- a/content/cumulus-linux-59/System-Configuration/Authentication-Authorization-and-Accounting/LDAP-Authentication-and-Authorization.md
+++ b/content/cumulus-linux-59/System-Configuration/Authentication-Authorization-and-Accounting/LDAP-Authentication-and-Authorization.md
@@ -123,15 +123,25 @@ Instead of running the installer and following the interactive prompts, as descr
    ```
 
 {{< /expand >}}
+
+<!-- vale off -->
+## Configure PAM to use LDAP
+<!-- vale on -->
+After installation, execute `sudo pam-auth-update --enable ldap` command
+
+```
+cumulus@switch:~$ sudo pam-auth-update --enable ldap
+```
+
 <!-- vale off -->
 ## Update the nslcd.conf File
 <!-- vale on -->
-After installation, update the main configuration file (`/etc/nslcd.conf`) to accommodate the expected LDAP server settings.
+Update the main configuration file (`/etc/nslcd.conf`) to accommodate the expected LDAP server settings.
 
 This section documents some of the more important options that relate to security and queries. For details on all the available configuration options, read the {{<exlink url="http://linux.die.net/man/5/nslcd.conf" text="nslcd.conf man page">}}.
 
 {{%notice note%}}
-After first editing the `/etc/nslcd.conf` file and/or enabling LDAP in the `/etc/nsswitch.conf` file, you must restart `netd` with the `sudo systemctl restart netd` command. If you disable LDAP, you need to restart the `netd` service.
+After first editing the `/etc/nslcd.conf` file and/or enabling LDAP in the `/etc/nsswitch.conf` file, you must restart `nvue` with the `sudo systemctl restart nvued.service` command. If you disable LDAP, you need to restart the `nvue` service.
 {{%/notice%}}
 
 ### Connection


### PR DESCRIPTION
Added a paragraph where we need to run command 'pam-auth-update --force --enable ldap' starting 5.9 onwards if not using NVUE to enable LDAP in Cumulus switch


See the following KB and RM for additional info
https://nvcrm.lightning.force.com/lightning/r/Knowledge__kav/ka0Vv00000038YvIAI/view

RM4296649

This note should also be pushed for flat file configuration of LDAP in Cumulus documentation for 5.10 and later. 

********************************************

Also fixed typo referencing netd in nslcd.conf since netd is deprecated starting 5.9 onwards.