### PR TITLE
document sleep, image claimer

### DIFF
--- a/content/nvidia-air-v2/Authentication.md
+++ b/content/nvidia-air-v2/Authentication.md
@@ -56,6 +56,7 @@ Roles are assigned to users in your NGC organization and apply to Personal API K
 | `air-image-uploader` | Can upload custom images |
 | `air-image-publisher` | Can publish images for public availability |
 | `air-image-sharer` | Can create cross-org image sharing links |
+| `air-image-claimer` | Can claim images shared from another organization |
 | `air-instructor` | Can create and manage training sessions |
 
 ### Scopes
@@ -74,6 +75,7 @@ Scopes are the permissions that the Air API checks to authorize requests. For Pe
 | `air:image_write` | Upload and edit images |
 | `air:image_publish` | Publish images for public availability (not restricted to any org) |
 | `air:image_sharing` | Create cross-org image share links |
+| `air:image_claiming` | Claim images shared from another organization |
 | `air:marketplace_demo_read` | View and interact with marketplace demos |
 | `air:marketplace_demo_write` | Create and edit marketplace demos |
 | `air:marketplace_demo_publish` | Publish demos to the marketplace |

--- a/content/nvidia-air-v2/Quick-Start.md
+++ b/content/nvidia-air-v2/Quick-Start.md
@@ -90,7 +90,7 @@ You can also rebuild all nodes in a simulation simultaneously by clicking the {{
 
 You can edit important attributes of a simulation with the {{<img src="/images/guides/nvidia-air-v2/Edit.png" alt="" width="22px" >}} **Edit** button in the **Topology** tab.
 - **Simulation Name** is the simulation name. Simulations can share the same name. Air assigns a unique identifier to each simulation to differentiate between each one.
-- **Sleep date** is when the simulation goes into sleep mode automatically; Air saves the state of the simulation and stores it to free up account resources.
+- **Sleep date** is when the simulation goes into sleep mode automatically; Air saves the state of the simulation and stores it to free up account resources. For details, see {{<link title="Simulation Management">}}.
 
 {{<img src="/images/guides/nvidia-air-v2/EditSim.png" alt="" width="400px">}}
 

--- a/content/nvidia-air-v2/Sharing-Images.md
+++ b/content/nvidia-air-v2/Sharing-Images.md
@@ -20,7 +20,9 @@ Image sharing requires specific roles assigned to your account:
 | Action | Required Role | Scope |
 |--------|---------------|-------|
 | Share an image (create claim code) | `AIR_IMAGE_SHARER` | `air:image_sharing` |
-| Claim a shared image | `AIR_IMAGE_UPLOADER` or `AIR_IMAGE_PUBLISHER` | `air:image_write` |
+| Claim a shared image | `AIR_IMAGE_UPLOADER`, `AIR_IMAGE_PUBLISHER`, or `AIR_IMAGE_CLAIMER` | `air:image_write` or `air:image_claiming` |
+
+The `AIR_IMAGE_CLAIMER` role grants only the ability to claim shared images. Assign this role to organizations that should receive shared images but should not be able to upload, edit, or publish their own.
 
 For information on how roles are assigned, see {{<link title="API Authentication">}}.
 

--- a/content/nvidia-air-v2/Simulation-Management.md
+++ b/content/nvidia-air-v2/Simulation-Management.md
@@ -103,6 +103,46 @@ You can revert a simulation only when:
 
 After the revert completes, the state badge changes to **Editable** and you can modify the topology again.
 
+## Sleep
+
+Sleep is the normal way to stop a running simulation while preserving its state. When a simulation goes to sleep, Air shuts down its nodes, saves a checkpoint of their disk state, and releases the compute resources. The simulation transitions through **Shutting Down** and **Saving** before reaching **Inactive**, where it stays until you start it again.
+
+Sleeping is reversible. Starting a slept simulation restores all nodes from the saved checkpoint, so any configuration changes and in-memory state captured at sleep time are preserved.
+
+### Putting a Simulation to Sleep Manually
+
+To put a running simulation to sleep:
+
+1. Open the simulation.
+2. In the action bar at the top of the page, click **Stop Simulation and Store Checkpoint**.
+
+The simulation transitions to **Saving** while the checkpoint is written, then to **Inactive**.
+
+To stop a simulation without saving a checkpoint, open the dropdown next to **Stop Simulation and Store Checkpoint** and select **Stop Simulation Without Checkpoint**. Any unsaved changes since the last checkpoint are lost.
+
+### Scheduling Automatic Sleep
+
+You can schedule a simulation to go to sleep automatically by setting a sleep date. When the sleep date is reached, Air puts the simulation to sleep and saves a checkpoint.
+
+To set or change the sleep date:
+
+1. Open the simulation.
+2. In the action bar at the top of the page, click **Edit Simulation**.
+3. Set the **Sleep date** and **Sleep time** to when you want the simulation to sleep. Times are entered in your local timezone and stored as UTC.
+4. Click **Save**.
+
+The sleep date persists across runs. Clear it if you no longer want the simulation to sleep automatically.
+
+{{%notice note%}}
+Free trial accounts have an automatic sleep date applied to their simulations and cannot remove it. Contact NVIDIA to upgrade your account if you need simulations that do not sleep automatically.
+{{%/notice%}}
+
+### Waking a Simulation
+
+To wake a sleeping simulation, start it the same way you would start any inactive simulation. By default, Air resumes from the most recent checkpoint. To wake from a different checkpoint, see [Starting from a Checkpoint](#starting-from-a-checkpoint).
+
+If the sleep date has already passed when you wake the simulation, Air clears it so the simulation does not immediately go back to sleep.
+
 ## Simulation History
 
 The History tab provides a detailed log of all events that occurred during your simulation's lifecycle. This is useful for understanding what happened to your simulation and for debugging issues.


### PR DESCRIPTION
## Summary
- Add `## Sleep` section to Simulation Management covering manual sleep, scheduled sleep, free-trial note, and waking
- Add `AIR_IMAGE_CLAIMER` role / `air:image_claiming` scope to Authentication tables
- Update Sharing-Images permissions table to include `AIR_IMAGE_CLAIMER` and explain when to use it
- Cross-link the sleep date mention in Quick Start to the new Sleep section

## Test plan
- [ ] Render Hugo locally and review Simulation-Management, Sharing-Images, Authentication, Quick-Start pages
- [ ] Confirm UI button labels (`Stop Simulation and Store Checkpoint`, `Edit Simulation`) match the live air-ngc.nvidia.com UI
- [ ] Verify role and scope additions match air-api `AIR_IMAGE_CLAIMER` enablement and `air:image_claiming` scope